### PR TITLE
Remove binary card images

### DIFF
--- a/early-access.html
+++ b/early-access.html
@@ -10,9 +10,9 @@
     <header class="p-6 flex justify-between items-center text-sm">
       <a href="index.html" class="font-bold hover:underline">Schwarz USA</a>
       <nav class="space-x-4 text-gray-300">
-        <a href="#" class="hover:underline">Cards</a>
-        <a href="#" class="hover:underline">Pricing</a>
-        <a href="#" class="hover:underline">Contact</a>
+        <a href="products.html" class="hover:underline">Products</a>
+        <a href="designs.html" class="hover:underline">Designs</a>
+        <a href="custom.html" class="hover:underline">Custom</a>
       </nav>
     </header>
     <main class="px-6 md:px-20 py-10 text-center">


### PR DESCRIPTION
## Summary
- drop sample card PNG files
- revert to placeholder icons on early-access page
- remove image grid from homepage and landing page
- restore simple welcome message on home page

## Testing
- `html5validator --root . --show-warnings --log INFO`

------
https://chatgpt.com/codex/tasks/task_e_68701413e5cc83289be2761d42efc66a