### PR TITLE
Add basic account system

### DIFF
--- a/account.html
+++ b/account.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Schwarz USA - Custom</title>
+  <title>Your Account - Schwarz USA</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="assets/app.js"></script>
   <style>
@@ -14,9 +14,6 @@
       background-size: auto;
       background-position: top left;
     }
-    .nav-active {
-      border-bottom: 4px solid #ff4f00; /* international orange */
-    }
   </style>
 </head>
 <body class="text-white font-sans">
@@ -26,7 +23,7 @@
     <nav class="space-x-6">
       <a href="products.html" class="hover:underline">Products</a>
       <a href="designs.html" class="hover:underline">Designs</a>
-      <a href="custom.html" class="hover:underline nav-active">Custom</a>
+      <a href="custom.html" class="hover:underline">Custom</a>
       <a href="technologies.html" class="hover:underline">Technologies</a>
     </nav>
     <div class="space-x-4 relative">
@@ -50,18 +47,48 @@
     </div>
   </header>
 
-  <!-- Page content -->
   <main class="pt-28 px-6">
-    <h1 class="text-3xl font-semibold">Customize Your Card</h1>
-    <p class="mt-4 text-gray-300">Create a personalized card tailored to you.</p>
+    <h1 class="text-3xl font-semibold mb-4">Account Details</h1>
+    <form id="profileForm" class="space-y-3 max-w-md mx-auto text-black">
+      <input id="shipping" class="w-full px-2 py-1 rounded" placeholder="Shipping Address" />
+      <input id="billing" class="w-full px-2 py-1 rounded" placeholder="Billing Address" />
+      <input id="payment" class="w-full px-2 py-1 rounded" placeholder="Payment Info" />
+      <button type="submit" class="bg-blue-500 text-white px-2 py-1 rounded w-full">Save Profile</button>
+    </form>
+    <div class="max-w-md mx-auto mt-6">
+      <h2 class="text-xl font-semibold mb-2">Orders</h2>
+      <ul id="ordersList" class="list-disc list-inside"></ul>
+    </div>
   </main>
 
   <script>
-    // Redirect to home page on Enter key press
-    document.addEventListener('keydown', function(e) {
-      if (e.key === 'Enter') {
+    document.addEventListener('DOMContentLoaded', () => {
+      renderProfileMenu();
+      updateCartMenu();
+      const p = loadProfile();
+      document.getElementById('shipping').value = p.shipping;
+      document.getElementById('billing').value = p.billing;
+      document.getElementById('payment').value = p.payment;
+      const list = document.getElementById('ordersList');
+      list.innerHTML = '';
+      p.orders.forEach((o, i) => {
+        const li = document.createElement('li');
+        li.textContent = `Order ${i + 1} - ${o.date} (${o.items.length} items)`;
+        list.appendChild(li);
+      });
+      document.getElementById('profileForm').addEventListener('submit', (e) => {
+        e.preventDefault();
+        const prof = loadProfile();
+        prof.shipping = document.getElementById('shipping').value;
+        prof.billing = document.getElementById('billing').value;
+        prof.payment = document.getElementById('payment').value;
+        saveProfile(prof);
+        alert('Profile saved');
+      });
+      document.getElementById('signOutBtn').addEventListener('click', () => {
+        signOut();
         window.location.href = 'home.html';
-      }
+      });
     });
   </script>
 </body>

--- a/assets/app.js
+++ b/assets/app.js
@@ -1,60 +1,82 @@
-function toggleMenu(menuId) {
-  const menu = document.getElementById(menuId);
-  const isHidden = menu.classList.contains('hidden');
-  document.getElementById('profileMenu').classList.add('hidden');
-  document.getElementById('cartMenu').classList.add('hidden');
-  if (isHidden) menu.classList.remove('hidden');
+function showMenu(id) {
+  document.getElementById(id).classList.remove('hidden');
+}
+
+function hideMenu(id) {
+  document.getElementById(id).classList.add('hidden');
+}
+
+function loadAccounts() {
+  const data = localStorage.getItem('accounts');
+  return data ? JSON.parse(data) : {};
+}
+
+function saveAccounts(accts) {
+  localStorage.setItem('accounts', JSON.stringify(accts));
+}
+
+function currentUser() {
+  return localStorage.getItem('currentUser');
+}
+
+function isSignedIn() {
+  return !!currentUser();
+}
+
+function signInUser(email, password) {
+  const accts = loadAccounts();
+  if (accts[email] && accts[email].password === password) {
+    localStorage.setItem('currentUser', email);
+    return true;
+  }
+  return false;
+}
+
+function createAccount(email, password) {
+  const accts = loadAccounts();
+  if (accts[email]) return false;
+  accts[email] = {
+    password: password,
+    profile: { shipping: '', billing: '', payment: '', cart: [], orders: [] }
+  };
+  saveAccounts(accts);
+  localStorage.setItem('currentUser', email);
+  return true;
+}
+
+function signOut() {
+  localStorage.removeItem('currentUser');
+  renderProfileMenu();
+  updateCartMenu();
 }
 
 function loadProfile() {
-  const data = localStorage.getItem('profile');
-  return data ? JSON.parse(data) : { shipping: '', billing: '', payment: '', cart: [], orders: [] };
+  const email = currentUser();
+  const accts = loadAccounts();
+  if (email && accts[email]) {
+    if (!accts[email].profile) {
+      accts[email].profile = { shipping: '', billing: '', payment: '', cart: [], orders: [] };
+      saveAccounts(accts);
+    }
+    return accts[email].profile;
+  }
+  return { shipping: '', billing: '', payment: '', cart: [], orders: [] };
 }
 
 function saveProfile(profile) {
-  localStorage.setItem('profile', JSON.stringify(profile));
-}
-
-function updateProfileInfo() {
-  const p = loadProfile();
-  document.getElementById('displayShipping').textContent = p.shipping || 'N/A';
-  document.getElementById('displayBilling').textContent = p.billing || 'N/A';
-  document.getElementById('displayPayment').textContent = p.payment || 'N/A';
-  const ordersList = document.getElementById('ordersList');
-  ordersList.innerHTML = '';
-  p.orders.forEach((o, i) => {
-    const li = document.createElement('li');
-    li.textContent = `Order ${i + 1} - ${o.date} (${o.items.length} items)`;
-    ordersList.appendChild(li);
-  });
-}
-
-function editProfile() {
-  const p = loadProfile();
-  document.getElementById('shipping').value = p.shipping;
-  document.getElementById('billing').value = p.billing;
-  document.getElementById('payment').value = p.payment;
-  document.getElementById('profileForm').classList.remove('hidden');
-  document.getElementById('profileInfo').classList.add('hidden');
-}
-
-function handleProfileSubmit(e) {
-  e.preventDefault();
-  const p = loadProfile();
-  p.shipping = document.getElementById('shipping').value;
-  p.billing = document.getElementById('billing').value;
-  p.payment = document.getElementById('payment').value;
-  saveProfile(p);
-  document.getElementById('profileForm').classList.add('hidden');
-  document.getElementById('profileInfo').classList.remove('hidden');
-  updateProfileInfo();
+  const email = currentUser();
+  if (!email) return;
+  const accts = loadAccounts();
+  accts[email].profile = profile;
+  saveAccounts(accts);
 }
 
 function updateCartMenu() {
   const p = loadProfile();
   const cartList = document.getElementById('cartItems');
+  if (!cartList) return;
   cartList.innerHTML = '';
-  p.cart.forEach((item, i) => {
+  p.cart.forEach(item => {
     const li = document.createElement('li');
     li.textContent = item;
     cartList.appendChild(li);
@@ -75,11 +97,26 @@ function checkout() {
   p.cart = [];
   saveProfile(p);
   updateCartMenu();
-  updateProfileInfo();
+}
+
+function renderProfileMenu() {
+  const signed = isSignedIn();
+  const signedDiv = document.getElementById('profileSigned');
+  const unsignedDiv = document.getElementById('profileUnsigned');
+  if (signedDiv && unsignedDiv) {
+    signedDiv.classList.toggle('hidden', !signed);
+    unsignedDiv.classList.toggle('hidden', signed);
+  }
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  updateProfileInfo();
+  renderProfileMenu();
   updateCartMenu();
-  document.getElementById('profileForm').addEventListener('submit', handleProfileSubmit);
+  const signOutBtn = document.getElementById('signOutBtn');
+  if (signOutBtn) {
+    signOutBtn.addEventListener('click', () => {
+      signOut();
+      window.location.href = 'home.html';
+    });
+  }
 });

--- a/designs.html
+++ b/designs.html
@@ -29,34 +29,26 @@
       <a href="custom.html" class="hover:underline">Custom</a>
       <a href="technologies.html" class="hover:underline">Technologies</a>
     </nav>
-    <div class="space-x-4">
-      <button onclick="toggleMenu('profileMenu')" class="hover:text-gray-300">👤</button>
-      <button onclick="toggleMenu('cartMenu')" class="hover:text-gray-300">🛒</button>
+    <div class="space-x-4 relative">
+      <button id="profileBtn" onmouseenter="showMenu('profileMenu')" class="hover:text-gray-300">👤</button>
+      <button id="cartBtn" onmouseenter="showMenu('cartMenu')" class="hover:text-gray-300">🛒</button>
+      <div id="profileMenu" onmouseleave="hideMenu('profileMenu')" class="hidden absolute right-0 mt-2 bg-gray-800 p-4 rounded shadow-lg z-50 text-sm text-white">
+        <div id="profileUnsigned">
+          <a href="sign-in.html" class="block hover:underline">Sign In</a>
+        </div>
+        <div id="profileSigned" class="hidden space-y-2">
+          <a href="account.html" class="block hover:underline">Account</a>
+          <a href="orders.html" class="block hover:underline">Orders</a>
+          <button id="signOutBtn" class="text-left hover:underline w-full">Sign Out</button>
+        </div>
+      </div>
+      <div id="cartMenu" onmouseleave="hideMenu('cartMenu')" class="hidden absolute right-12 mt-2 bg-gray-800 p-4 rounded shadow-lg z-50 text-sm text-white">
+        <p class="font-semibold">Cart</p>
+        <ul id="cartItems" class="list-disc list-inside mb-2"></ul>
+        <button onclick="checkout()" class="bg-green-500 text-white px-2 py-1 rounded w-full">Checkout</button>
+      </div>
     </div>
   </header>
-
-  <!-- Menus -->
-  <div id="profileMenu" class="hidden absolute right-6 top-16 bg-gray-800 p-4 rounded shadow-lg z-50 text-sm">
-    <form id="profileForm" class="space-y-2 text-black">
-      <input id="shipping" class="w-full px-2 py-1 rounded" placeholder="Shipping Address" />
-      <input id="billing" class="w-full px-2 py-1 rounded" placeholder="Billing Address" />
-      <input id="payment" class="w-full px-2 py-1 rounded" placeholder="Payment Info" />
-      <button type="submit" class="bg-blue-500 text-white px-2 py-1 rounded w-full">Save Profile</button>
-    </form>
-    <div id="profileInfo" class="hidden text-white text-left mt-2">
-      <p><strong>Shipping:</strong> <span id="displayShipping"></span></p>
-      <p><strong>Billing:</strong> <span id="displayBilling"></span></p>
-      <p><strong>Payment:</strong> <span id="displayPayment"></span></p>
-      <p class="mt-2 font-semibold">Orders:</p>
-      <ul id="ordersList" class="list-disc list-inside"></ul>
-      <button onclick="editProfile()" class="bg-blue-500 text-white px-2 py-1 rounded mt-2 w-full">Edit</button>
-    </div>
-  </div>
-  <div id="cartMenu" class="hidden absolute right-16 top-16 bg-gray-800 p-4 rounded shadow-lg z-50 text-sm text-white">
-    <p class="font-semibold">Cart</p>
-    <ul id="cartItems" class="list-disc list-inside mb-2"></ul>
-    <button onclick="checkout()" class="bg-green-500 text-white px-2 py-1 rounded w-full">Checkout</button>
-  </div>
 
   <!-- Page content -->
   <main class="pt-28 px-6">

--- a/early-access.html
+++ b/early-access.html
@@ -10,9 +10,9 @@
     <header class="p-6 flex justify-between items-center text-sm">
       <a href="index.html" class="font-bold hover:underline">Schwarz USA</a>
       <nav class="space-x-4 text-gray-300">
-        <a href="#" class="hover:underline">Cards</a>
-        <a href="#" class="hover:underline">Pricing</a>
-        <a href="#" class="hover:underline">Contact</a>
+        <a href="products.html" class="hover:underline">Products</a>
+        <a href="designs.html" class="hover:underline">Designs</a>
+        <a href="custom.html" class="hover:underline">Custom</a>
       </nav>
     </header>
     <main class="px-6 md:px-20 py-10 text-center">

--- a/home.html
+++ b/home.html
@@ -29,34 +29,26 @@
       <a href="custom.html" class="hover:underline">Custom</a>
       <a href="technologies.html" class="hover:underline">Technologies</a>
     </nav>
-    <div class="space-x-4">
-      <button onclick="toggleMenu('profileMenu')" class="hover:text-gray-300">👤</button>
-      <button onclick="toggleMenu('cartMenu')" class="hover:text-gray-300">🛒</button>
+    <div class="space-x-4 relative">
+      <button id="profileBtn" onmouseenter="showMenu('profileMenu')" class="hover:text-gray-300">👤</button>
+      <button id="cartBtn" onmouseenter="showMenu('cartMenu')" class="hover:text-gray-300">🛒</button>
+      <div id="profileMenu" onmouseleave="hideMenu('profileMenu')" class="hidden absolute right-0 mt-2 bg-gray-800 p-4 rounded shadow-lg z-50 text-sm text-white">
+        <div id="profileUnsigned">
+          <a href="sign-in.html" class="block hover:underline">Sign In</a>
+        </div>
+        <div id="profileSigned" class="hidden space-y-2">
+          <a href="account.html" class="block hover:underline">Account</a>
+          <a href="orders.html" class="block hover:underline">Orders</a>
+          <button id="signOutBtn" class="text-left hover:underline w-full">Sign Out</button>
+        </div>
+      </div>
+      <div id="cartMenu" onmouseleave="hideMenu('cartMenu')" class="hidden absolute right-12 mt-2 bg-gray-800 p-4 rounded shadow-lg z-50 text-sm text-white">
+        <p class="font-semibold">Cart</p>
+        <ul id="cartItems" class="list-disc list-inside mb-2"></ul>
+        <button onclick="checkout()" class="bg-green-500 text-white px-2 py-1 rounded w-full">Checkout</button>
+      </div>
     </div>
   </header>
-
-  <!-- Menus -->
-  <div id="profileMenu" class="hidden absolute right-6 top-16 bg-gray-800 p-4 rounded shadow-lg z-50 text-sm">
-    <form id="profileForm" class="space-y-2 text-black">
-      <input id="shipping" class="w-full px-2 py-1 rounded" placeholder="Shipping Address" />
-      <input id="billing" class="w-full px-2 py-1 rounded" placeholder="Billing Address" />
-      <input id="payment" class="w-full px-2 py-1 rounded" placeholder="Payment Info" />
-      <button type="submit" class="bg-blue-500 text-white px-2 py-1 rounded w-full">Save Profile</button>
-    </form>
-    <div id="profileInfo" class="hidden text-white text-left mt-2">
-      <p><strong>Shipping:</strong> <span id="displayShipping"></span></p>
-      <p><strong>Billing:</strong> <span id="displayBilling"></span></p>
-      <p><strong>Payment:</strong> <span id="displayPayment"></span></p>
-      <p class="mt-2 font-semibold">Orders:</p>
-      <ul id="ordersList" class="list-disc list-inside"></ul>
-      <button onclick="editProfile()" class="bg-blue-500 text-white px-2 py-1 rounded mt-2 w-full">Edit</button>
-    </div>
-  </div>
-  <div id="cartMenu" class="hidden absolute right-16 top-16 bg-gray-800 p-4 rounded shadow-lg z-50 text-sm text-white">
-    <p class="font-semibold">Cart</p>
-    <ul id="cartItems" class="list-disc list-inside mb-2"></ul>
-    <button onclick="checkout()" class="bg-green-500 text-white px-2 py-1 rounded w-full">Checkout</button>
-  </div>
 
   <!-- Page content -->
   <main class="pt-28 px-6">

--- a/orders.html
+++ b/orders.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Schwarz USA - Custom</title>
+  <title>Your Orders - Schwarz USA</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="assets/app.js"></script>
   <style>
@@ -14,9 +14,6 @@
       background-size: auto;
       background-position: top left;
     }
-    .nav-active {
-      border-bottom: 4px solid #ff4f00; /* international orange */
-    }
   </style>
 </head>
 <body class="text-white font-sans">
@@ -26,7 +23,7 @@
     <nav class="space-x-6">
       <a href="products.html" class="hover:underline">Products</a>
       <a href="designs.html" class="hover:underline">Designs</a>
-      <a href="custom.html" class="hover:underline nav-active">Custom</a>
+      <a href="custom.html" class="hover:underline">Custom</a>
       <a href="technologies.html" class="hover:underline">Technologies</a>
     </nav>
     <div class="space-x-4 relative">
@@ -50,18 +47,31 @@
     </div>
   </header>
 
-  <!-- Page content -->
   <main class="pt-28 px-6">
-    <h1 class="text-3xl font-semibold">Customize Your Card</h1>
-    <p class="mt-4 text-gray-300">Create a personalized card tailored to you.</p>
+    <h1 class="text-3xl font-semibold mb-4">Your Orders</h1>
+    <ul id="ordersList" class="list-disc list-inside max-w-md mx-auto"></ul>
   </main>
 
   <script>
-    // Redirect to home page on Enter key press
-    document.addEventListener('keydown', function(e) {
-      if (e.key === 'Enter') {
-        window.location.href = 'home.html';
+    document.addEventListener('DOMContentLoaded', () => {
+      renderProfileMenu();
+      updateCartMenu();
+      const p = loadProfile();
+      const list = document.getElementById('ordersList');
+      list.innerHTML = '';
+      if (p.orders.length === 0) {
+        list.innerHTML = '<li>No orders yet.</li>';
+      } else {
+        p.orders.forEach((o, i) => {
+          const li = document.createElement('li');
+          li.textContent = `Order ${i + 1} - ${o.date} (${o.items.length} items)`;
+          list.appendChild(li);
+        });
       }
+      document.getElementById('signOutBtn').addEventListener('click', () => {
+        signOut();
+        window.location.href = 'home.html';
+      });
     });
   </script>
 </body>

--- a/products.html
+++ b/products.html
@@ -29,34 +29,26 @@
       <a href="custom.html" class="hover:underline">Custom</a>
       <a href="technologies.html" class="hover:underline">Technologies</a>
     </nav>
-    <div class="space-x-4">
-      <button onclick="toggleMenu('profileMenu')" class="hover:text-gray-300">👤</button>
-      <button onclick="toggleMenu('cartMenu')" class="hover:text-gray-300">🛒</button>
+    <div class="space-x-4 relative">
+      <button id="profileBtn" onmouseenter="showMenu('profileMenu')" class="hover:text-gray-300">👤</button>
+      <button id="cartBtn" onmouseenter="showMenu('cartMenu')" class="hover:text-gray-300">🛒</button>
+      <div id="profileMenu" onmouseleave="hideMenu('profileMenu')" class="hidden absolute right-0 mt-2 bg-gray-800 p-4 rounded shadow-lg z-50 text-sm text-white">
+        <div id="profileUnsigned">
+          <a href="sign-in.html" class="block hover:underline">Sign In</a>
+        </div>
+        <div id="profileSigned" class="hidden space-y-2">
+          <a href="account.html" class="block hover:underline">Account</a>
+          <a href="orders.html" class="block hover:underline">Orders</a>
+          <button id="signOutBtn" class="text-left hover:underline w-full">Sign Out</button>
+        </div>
+      </div>
+      <div id="cartMenu" onmouseleave="hideMenu('cartMenu')" class="hidden absolute right-12 mt-2 bg-gray-800 p-4 rounded shadow-lg z-50 text-sm text-white">
+        <p class="font-semibold">Cart</p>
+        <ul id="cartItems" class="list-disc list-inside mb-2"></ul>
+        <button onclick="checkout()" class="bg-green-500 text-white px-2 py-1 rounded w-full">Checkout</button>
+      </div>
     </div>
   </header>
-
-  <!-- Menus -->
-  <div id="profileMenu" class="hidden absolute right-6 top-16 bg-gray-800 p-4 rounded shadow-lg z-50 text-sm">
-    <form id="profileForm" class="space-y-2 text-black">
-      <input id="shipping" class="w-full px-2 py-1 rounded" placeholder="Shipping Address" />
-      <input id="billing" class="w-full px-2 py-1 rounded" placeholder="Billing Address" />
-      <input id="payment" class="w-full px-2 py-1 rounded" placeholder="Payment Info" />
-      <button type="submit" class="bg-blue-500 text-white px-2 py-1 rounded w-full">Save Profile</button>
-    </form>
-    <div id="profileInfo" class="hidden text-white text-left mt-2">
-      <p><strong>Shipping:</strong> <span id="displayShipping"></span></p>
-      <p><strong>Billing:</strong> <span id="displayBilling"></span></p>
-      <p><strong>Payment:</strong> <span id="displayPayment"></span></p>
-      <p class="mt-2 font-semibold">Orders:</p>
-      <ul id="ordersList" class="list-disc list-inside"></ul>
-      <button onclick="editProfile()" class="bg-blue-500 text-white px-2 py-1 rounded mt-2 w-full">Edit</button>
-    </div>
-  </div>
-  <div id="cartMenu" class="hidden absolute right-16 top-16 bg-gray-800 p-4 rounded shadow-lg z-50 text-sm text-white">
-    <p class="font-semibold">Cart</p>
-    <ul id="cartItems" class="list-disc list-inside mb-2"></ul>
-    <button onclick="checkout()" class="bg-green-500 text-white px-2 py-1 rounded w-full">Checkout</button>
-  </div>
 
   <!-- Page content -->
   <main class="pt-28 px-6">

--- a/sign-in.html
+++ b/sign-in.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sign In - Schwarz USA</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="assets/app.js"></script>
+</head>
+<body class="bg-black flex items-center justify-center min-h-screen text-white font-sans">
+  <div class="bg-gray-800 p-6 rounded w-80">
+    <h1 class="text-xl font-semibold mb-4 text-center">Account Access</h1>
+    <form id="signForm" class="space-y-3">
+      <input id="email" type="email" placeholder="Email" required class="w-full px-3 py-2 text-black rounded" />
+      <input id="password" type="password" placeholder="Password" required class="w-full px-3 py-2 text-black rounded" />
+      <button type="submit" class="w-full bg-yellow-500 text-black py-2 rounded">Sign In</button>
+    </form>
+    <p id="toggleMsg" class="text-sm mt-4 text-center">
+      <span>Need an account?</span>
+      <button id="toggleBtn" class="underline ml-1">Sign Up</button>
+    </p>
+  </div>
+  <script>
+    let mode = 'signin';
+    const form = document.getElementById('signForm');
+    const emailInput = document.getElementById('email');
+    const passwordInput = document.getElementById('password');
+    const toggleBtn = document.getElementById('toggleBtn');
+    const toggleMsg = document.getElementById('toggleMsg');
+
+    toggleBtn.addEventListener('click', () => {
+      mode = mode === 'signin' ? 'signup' : 'signin';
+      form.querySelector('button[type="submit"]').textContent = mode === 'signin' ? 'Sign In' : 'Create Account';
+      toggleBtn.textContent = mode === 'signin' ? 'Sign Up' : 'Sign In';
+      toggleMsg.firstChild.textContent = mode === 'signin' ? 'Need an account?' : 'Already have an account?';
+    });
+
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      const email = emailInput.value.trim();
+      const password = passwordInput.value;
+      if (mode === 'signin') {
+        if (signInUser(email, password)) {
+          window.location.href = 'home.html';
+        } else {
+          alert('Invalid credentials');
+        }
+      } else {
+        if (createAccount(email, password)) {
+          window.location.href = 'home.html';
+        } else {
+          alert('Account already exists');
+        }
+      }
+    });
+  </script>
+</body>
+</html>

--- a/technologies.html
+++ b/technologies.html
@@ -29,34 +29,26 @@
       <a href="custom.html" class="hover:underline">Custom</a>
       <a href="technologies.html" class="hover:underline nav-active">Technologies</a>
     </nav>
-    <div class="space-x-4">
-      <button onclick="toggleMenu('profileMenu')" class="hover:text-gray-300">👤</button>
-      <button onclick="toggleMenu('cartMenu')" class="hover:text-gray-300">🛒</button>
+    <div class="space-x-4 relative">
+      <button id="profileBtn" onmouseenter="showMenu('profileMenu')" class="hover:text-gray-300">👤</button>
+      <button id="cartBtn" onmouseenter="showMenu('cartMenu')" class="hover:text-gray-300">🛒</button>
+      <div id="profileMenu" onmouseleave="hideMenu('profileMenu')" class="hidden absolute right-0 mt-2 bg-gray-800 p-4 rounded shadow-lg z-50 text-sm text-white">
+        <div id="profileUnsigned">
+          <a href="sign-in.html" class="block hover:underline">Sign In</a>
+        </div>
+        <div id="profileSigned" class="hidden space-y-2">
+          <a href="account.html" class="block hover:underline">Account</a>
+          <a href="orders.html" class="block hover:underline">Orders</a>
+          <button id="signOutBtn" class="text-left hover:underline w-full">Sign Out</button>
+        </div>
+      </div>
+      <div id="cartMenu" onmouseleave="hideMenu('cartMenu')" class="hidden absolute right-12 mt-2 bg-gray-800 p-4 rounded shadow-lg z-50 text-sm text-white">
+        <p class="font-semibold">Cart</p>
+        <ul id="cartItems" class="list-disc list-inside mb-2"></ul>
+        <button onclick="checkout()" class="bg-green-500 text-white px-2 py-1 rounded w-full">Checkout</button>
+      </div>
     </div>
   </header>
-
-  <!-- Menus -->
-  <div id="profileMenu" class="hidden absolute right-6 top-16 bg-gray-800 p-4 rounded shadow-lg z-50 text-sm">
-    <form id="profileForm" class="space-y-2 text-black">
-      <input id="shipping" class="w-full px-2 py-1 rounded" placeholder="Shipping Address" />
-      <input id="billing" class="w-full px-2 py-1 rounded" placeholder="Billing Address" />
-      <input id="payment" class="w-full px-2 py-1 rounded" placeholder="Payment Info" />
-      <button type="submit" class="bg-blue-500 text-white px-2 py-1 rounded w-full">Save Profile</button>
-    </form>
-    <div id="profileInfo" class="hidden text-white text-left mt-2">
-      <p><strong>Shipping:</strong> <span id="displayShipping"></span></p>
-      <p><strong>Billing:</strong> <span id="displayBilling"></span></p>
-      <p><strong>Payment:</strong> <span id="displayPayment"></span></p>
-      <p class="mt-2 font-semibold">Orders:</p>
-      <ul id="ordersList" class="list-disc list-inside"></ul>
-      <button onclick="editProfile()" class="bg-blue-500 text-white px-2 py-1 rounded mt-2 w-full">Edit</button>
-    </div>
-  </div>
-  <div id="cartMenu" class="hidden absolute right-16 top-16 bg-gray-800 p-4 rounded shadow-lg z-50 text-sm text-white">
-    <p class="font-semibold">Cart</p>
-    <ul id="cartItems" class="list-disc list-inside mb-2"></ul>
-    <button onclick="checkout()" class="bg-green-500 text-white px-2 py-1 rounded w-full">Checkout</button>
-  </div>
 
   <!-- Page content -->
   <main class="pt-28 px-6">


### PR DESCRIPTION
## Summary
- add sign in, account, and orders pages
- implement simple localStorage-based account storage in app.js
- update navigation dropdown with sign in/out links
- attach profile and cart menus to hover actions

## Testing
- `html5validator --root . --show-warnings --log INFO`

------
https://chatgpt.com/codex/tasks/task_e_68701413e5cc83289be2761d42efc66a