### PR TITLE
Position design arrows around preview

### DIFF
--- a/customize-card.html
+++ b/customize-card.html
@@ -17,10 +17,10 @@
       border-bottom: 4px solid #ff4f00; /* international orange */
     }
     .arrow {
-      font-size: 2rem;
+      font-size: 2.5rem;
       font-weight: 300;
       display: inline-block;
-      transform: scaleX(1.5);
+      transform: scaleX(1.6);
       line-height: 1;
       user-select: none;
     }

--- a/customize-card.html
+++ b/customize-card.html
@@ -16,6 +16,14 @@
     .nav-active {
       border-bottom: 4px solid #ff4f00; /* international orange */
     }
+    .arrow {
+      font-size: 2rem;
+      font-weight: 300;
+      display: inline-block;
+      transform: scaleX(1.5);
+      line-height: 1;
+      user-select: none;
+    }
   </style>
 </head>
 <body class="text-white font-sans">
@@ -35,18 +43,18 @@
     <h1 class="text-3xl font-semibold">Customize Your Card</h1>
     <p class="text-gray-300">Apply different designs, borders and colors.</p>
     <div class="flex flex-col items-center">
-      <button onclick="nextBorder()" class="text-2xl mb-2">▲</button>
-      <div id="cardPreview" class="w-64 h-40 relative flex items-center justify-center rounded border-4 overflow-hidden">
-        <img id="designImage" src="assets/Test%20Card.png" alt="Design preview" class="absolute inset-0 w-full h-full object-cover hidden">
-        <span id="designNumber" class="text-5xl"></span>
-        <span id="borderLetter" class="absolute top-1 left-1 text-sm"></span>
+      <button onclick="nextBorder()" class="arrow mb-2">^</button>
+      <div class="flex items-center">
+        <button onclick="prevDesign()" class="arrow mr-2">&lt;</button>
+        <div id="cardPreview" class="w-64 h-40 relative flex items-center justify-center rounded border-4 overflow-hidden">
+          <img id="designImage" src="assets/Test%20Card.png" alt="Design preview" class="absolute inset-0 w-full h-full object-cover hidden">
+          <span id="designNumber" class="text-5xl"></span>
+          <span id="borderLetter" class="absolute top-1 left-1 text-sm"></span>
+        </div>
+        <button onclick="nextDesign()" class="arrow ml-2">&gt;</button>
       </div>
-      <button onclick="prevBorder()" class="text-2xl mt-2">▼</button>
-    </div>
-    <div class="flex items-center space-x-6">
-      <button onclick="prevDesign()" class="text-2xl">◀</button>
-      <span class="text-gray-400">Design</span>
-      <button onclick="nextDesign()" class="text-2xl">▶</button>
+      <button onclick="prevBorder()" class="arrow mt-2">v</button>
+      <span class="text-gray-400 mt-2">Design</span>
     </div>
     <div class="flex space-x-6">
       <div id="color-black" class="color-option w-8 h-8 rounded-full bg-black border border-white cursor-pointer transition-transform" onclick="selectColor('black')"></div>
@@ -62,6 +70,7 @@
     let designIndex = 0;
     let selectedColor = 'black';
     let selectedColorName = 'black';
+    const borderLetterColors = ['#f87171','#fb923c','#fbbf24','#34d399','#60a5fa','#a78bfa','#f472b6','#4ade80','#facc15','#fda4af'];
     const designColorMap = {
       black: 'silver',
       white: 'black',
@@ -70,7 +79,14 @@
       function updatePreview() {
         const designNumberEl = document.getElementById('designNumber');
         const designImageEl = document.getElementById('designImage');
-        document.getElementById('cardPreview').style.backgroundColor = selectedColor;
+        const cardPreviewEl = document.getElementById('cardPreview');
+        cardPreviewEl.style.backgroundColor = selectedColor;
+        cardPreviewEl.style.borderColor = 'transparent';
+        if (borderIndex === 0) {
+          cardPreviewEl.style.borderWidth = '0px';
+        } else {
+          cardPreviewEl.style.borderWidth = '4px';
+        }
         designNumberEl.style.color = designColorMap[selectedColorName] || 'black';
 
         if (designNumbers[designIndex] === 1) {
@@ -81,7 +97,9 @@
           designImageEl.classList.add('hidden');
           designNumberEl.textContent = designNumbers[designIndex];
         }
-        document.getElementById('borderLetter').textContent = borderLetters[borderIndex];
+        const borderLetterEl = document.getElementById('borderLetter');
+        borderLetterEl.textContent = borderLetters[borderIndex];
+        borderLetterEl.style.color = borderLetterColors[borderIndex % borderLetterColors.length];
       }
     function nextBorder() { borderIndex = (borderIndex + 1) % borderLetters.length; updatePreview(); }
     function prevBorder() { borderIndex = (borderIndex - 1 + borderLetters.length) % borderLetters.length; updatePreview(); }


### PR DESCRIPTION
## Summary
- place left/right design buttons beside the card preview
- keep up/down arrows styled the same as the others
- remove the border when the first border option is selected

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68729b2df14c8328a5d46da1da2953f0