### PR TITLE
Add modern card pages with order modal

### DIFF
--- a/assets/order.js
+++ b/assets/order.js
@@ -1,0 +1,41 @@
+const modal = document.getElementById('orderModal');
+const modalInfo = document.getElementById('modalInfo');
+const orderForm = document.getElementById('orderForm');
+const designCodeInput = document.getElementById('designCode');
+
+function openOrderModal(code) {
+  designCodeInput.value = code || '';
+  modal.classList.remove('hidden');
+  modalInfo.classList.remove('hidden');
+  orderForm.classList.add('hidden');
+}
+
+document.querySelectorAll('.order-btn').forEach(btn => {
+  btn.addEventListener('click', () => {
+    openOrderModal(btn.dataset.code);
+  });
+});
+
+document.getElementById('acknowledgeBtn').addEventListener('click', () => {
+  modalInfo.classList.add('hidden');
+  orderForm.classList.remove('hidden');
+});
+
+orderForm.addEventListener('submit', function(e) {
+  e.preventDefault();
+  const formData = new FormData(orderForm);
+  const body =
+    `Name: ${formData.get('name')}` + '\n' +
+    `Email: ${formData.get('email')}` + '\n' +
+    `Address: ${formData.get('address')}` + '\n' +
+    `Design Code: ${formData.get('design')}` + '\n' +
+    `Notes: ${formData.get('notes')}`;
+  window.location.href = `mailto:orders@schwarzusa.us?subject=Card%20Order&body=${encodeURIComponent(body)}`;
+  modal.classList.add('hidden');
+});
+
+modal.addEventListener('click', (e) => {
+  if (e.target === modal) {
+    modal.classList.add('hidden');
+  }
+});

--- a/customize-card.html
+++ b/customize-card.html
@@ -31,29 +31,32 @@
   </header>
 
   <!-- Page content -->
-  <main class="pt-28 px-6 text-center flex flex-col items-center space-y-6">
-    <h1 class="text-3xl font-semibold">Customize Your Card</h1>
-    <p class="text-gray-300">Apply different designs, borders and colors.</p>
-    <div class="flex flex-col items-center">
-      <button onclick="nextBorder()" class="text-3xl mb-2">&#x2227;</button>
-      <div id="cardPreview" class="w-64 h-40 relative flex items-center justify-center rounded border-4 overflow-hidden">
-        <img id="designImage" src="assets/Test%20Card.png" alt="Design preview" class="absolute inset-0 w-full h-full object-cover hidden">
-        <span id="designNumber" class="text-5xl"></span>
-        <span id="borderLetter" class="absolute top-1 left-1 text-sm"></span>
+  <main class="pt-28 px-6 flex flex-col items-center space-y-8">
+    <h1 class="text-3xl font-semibold text-center">Customize Your Card</h1>
+    <div class="flex flex-col md:flex-row md:space-x-10 w-full max-w-4xl">
+      <div class="flex flex-col items-center space-y-4 md:w-1/2">
+        <button onclick="nextBorder()" class="text-3xl">&#x2227;</button>
+        <div id="cardPreview" class="w-64 h-40 relative flex items-center justify-center rounded border-4 overflow-hidden bg-black">
+          <img id="designImage" src="assets/Placeholder_card.png" alt="Design preview" class="absolute inset-0 w-full h-full object-cover hidden" />
+          <span id="designNumber" class="text-5xl"></span>
+          <span id="borderLetter" class="absolute top-1 left-1 text-sm"></span>
+        </div>
+        <button onclick="prevBorder()" class="text-3xl">&#x2228;</button>
       </div>
-      <button onclick="prevBorder()" class="text-3xl mt-2">&#x2228;</button>
+      <div class="flex flex-col items-center justify-center space-y-6 md:w-1/2 mt-8 md:mt-0">
+        <div class="flex items-center space-x-6">
+          <button onclick="prevDesign()" class="text-3xl">&#x2329;</button>
+          <span class="text-gray-400">Design</span>
+          <button onclick="nextDesign()" class="text-3xl">&#x232A;</button>
+        </div>
+        <div class="flex space-x-6">
+          <div id="color-black" class="color-option w-8 h-8 rounded-full bg-black border border-white cursor-pointer transition-transform" onclick="selectColor('black')"></div>
+          <div id="color-white" class="color-option w-8 h-8 rounded-full bg-white border border-gray-400 cursor-pointer transition-transform" onclick="selectColor('white')"></div>
+          <div id="color-gold" class="color-option w-8 h-8 rounded-full bg-yellow-500 border border-yellow-200 cursor-pointer transition-transform" onclick="selectColor('gold')"></div>
+        </div>
+        <button class="order-btn bg-green-600 px-4 py-2 rounded text-white" data-code="">Order</button>
+      </div>
     </div>
-    <div class="flex items-center space-x-6">
-      <button onclick="prevDesign()" class="text-3xl">&#x2329;</button>
-      <span class="text-gray-400">Design</span>
-      <button onclick="nextDesign()" class="text-3xl">&#x232A;</button>
-    </div>
-    <div class="flex space-x-6">
-      <div id="color-black" class="color-option w-8 h-8 rounded-full bg-black border border-white cursor-pointer transition-transform" onclick="selectColor('black')"></div>
-      <div id="color-white" class="color-option w-8 h-8 rounded-full bg-white border border-gray-400 cursor-pointer transition-transform" onclick="selectColor('white')"></div>
-      <div id="color-gold" class="color-option w-8 h-8 rounded-full bg-yellow-500 border border-yellow-200 cursor-pointer transition-transform" onclick="selectColor('gold')"></div>
-    </div>
-    <button class="bg-green-600 px-4 py-2 rounded text-white mt-4">Order</button>
   </main>
   <script>
     const borderLetters = 'ABCDEFGHIJ'.split('');
@@ -76,7 +79,7 @@
         designNumberEl.style.color = designColorMap[selectedColorName] || 'black';
 
         if (designNumbers[designIndex] === 1) {
-          designImageEl.src = 'assets/Test%20Card.png';
+          designImageEl.src = 'assets/Placeholder_card.png';
           designImageEl.classList.remove('hidden');
           designNumberEl.textContent = '';
         } else {
@@ -84,6 +87,8 @@
           designNumberEl.textContent = designNumbers[designIndex];
         }
         document.getElementById('borderLetter').textContent = borderLetters[borderIndex];
+        const orderBtn = document.querySelector('.order-btn');
+        if (orderBtn) orderBtn.dataset.code = designNumbers[designIndex] + borderLetters[borderIndex];
       }
     function nextBorder() { borderIndex = (borderIndex + 1) % borderLetters.length; updatePreview(); }
     function prevBorder() { borderIndex = (borderIndex - 1 + borderLetters.length) % borderLetters.length; updatePreview(); }
@@ -97,7 +102,24 @@
       if (el) { el.classList.add('ring-4','scale-110'); }
       updatePreview();
     }
-    document.addEventListener('DOMContentLoaded', () => { selectColor('black'); updatePreview(); });
+  document.addEventListener('DOMContentLoaded', () => { selectColor('black'); updatePreview(); });
   </script>
+  <div id="orderModal" class="hidden fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-50">
+    <div class="bg-white text-black p-6 rounded w-full max-w-md">
+      <div id="modalInfo">
+        <p class="mb-4">Here’s how it works:<br>1. You submit your shipping address.<br>2. We send you a return box for your old card.<br>3. We create and send your new card along with your old card.</p>
+        <button id="acknowledgeBtn" class="bg-gray-800 text-white px-4 py-2 rounded w-full">Acknowledge</button>
+      </div>
+      <form id="orderForm" class="hidden mt-4 space-y-4">
+        <input type="text" name="name" placeholder="Name" required class="w-full border p-2" />
+        <input type="email" name="email" placeholder="Email" required class="w-full border p-2" />
+        <input type="text" name="address" placeholder="Address" required class="w-full border p-2" />
+        <input type="text" name="design" id="designCode" readonly class="w-full border p-2" />
+        <textarea name="notes" placeholder="Additional notes" class="w-full border p-2"></textarea>
+        <button type="submit" class="bg-orange-600 text-white px-4 py-2 rounded w-full">Submit</button>
+      </form>
+    </div>
+  </div>
+  <script src="assets/order.js"></script>
 </body>
 </html>

--- a/designs.html
+++ b/designs.html
@@ -32,8 +32,33 @@
 
   <!-- Page content -->
   <main class="pt-28 px-6">
-    <h1 class="text-3xl font-semibold">Design Gallery</h1>
-    <p class="mt-4 text-gray-300">Browse sample designs and inspirations.</p>
+    <h1 class="text-3xl font-semibold text-center mb-6">Designs</h1>
+    <div class="grid gap-8 sm:grid-cols-2 lg:grid-cols-3 max-w-5xl mx-auto">
+      <div class="bg-gray-800 p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
+        <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
+        <button class="order-btn bg-orange-600 hover:bg-orange-700 px-4 py-2 rounded text-white w-full" data-code="B1">Order</button>
+      </div>
+      <div class="bg-gray-800 p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
+        <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
+        <button class="order-btn bg-orange-600 hover:bg-orange-700 px-4 py-2 rounded text-white w-full" data-code="B2">Order</button>
+      </div>
+      <div class="bg-gray-800 p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
+        <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
+        <button class="order-btn bg-orange-600 hover:bg-orange-700 px-4 py-2 rounded text-white w-full" data-code="B3">Order</button>
+      </div>
+      <div class="bg-gray-800 p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
+        <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
+        <button class="order-btn bg-orange-600 hover:bg-orange-700 px-4 py-2 rounded text-white w-full" data-code="B4">Order</button>
+      </div>
+      <div class="bg-gray-800 p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
+        <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
+        <button class="order-btn bg-orange-600 hover:bg-orange-700 px-4 py-2 rounded text-white w-full" data-code="B5">Order</button>
+      </div>
+      <div class="bg-gray-800 p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
+        <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
+        <button class="order-btn bg-orange-600 hover:bg-orange-700 px-4 py-2 rounded text-white w-full" data-code="B6">Order</button>
+      </div>
+    </div>
   </main>
 
   <script>
@@ -44,5 +69,22 @@
       }
     });
   </script>
+  <div id="orderModal" class="hidden fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-50">
+    <div class="bg-white text-black p-6 rounded w-full max-w-md">
+      <div id="modalInfo">
+        <p class="mb-4">Here’s how it works:<br>1. You submit your shipping address.<br>2. We send you a return box for your old card.<br>3. We create and send your new card along with your old card.</p>
+        <button id="acknowledgeBtn" class="bg-gray-800 text-white px-4 py-2 rounded w-full">Acknowledge</button>
+      </div>
+      <form id="orderForm" class="hidden mt-4 space-y-4">
+        <input type="text" name="name" placeholder="Name" required class="w-full border p-2" />
+        <input type="email" name="email" placeholder="Email" required class="w-full border p-2" />
+        <input type="text" name="address" placeholder="Address" required class="w-full border p-2" />
+        <input type="text" name="design" id="designCode" readonly class="w-full border p-2" />
+        <textarea name="notes" placeholder="Additional notes" class="w-full border p-2"></textarea>
+        <button type="submit" class="bg-orange-600 text-white px-4 py-2 rounded w-full">Submit</button>
+      </form>
+    </div>
+  </div>
+  <script src="assets/order.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Schwarz USA - Coming Soon</title>
+    <title>Schwarz USA</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <style>
       body {
@@ -15,21 +15,24 @@
       }
     </style>
   </head>
-  <body class="relative text-white font-sans">
-    <main class="relative z-10 flex flex-col items-center justify-center min-h-screen text-center px-6">
-      <h2 class="text-2xl md:text-4xl text-yellow-400 mb-2 mt-10 uppercase tracking-wide font-bold">
-        Coming Soon
-      </h2>
-      <h1 class="text-5xl md:text-6xl font-bold mb-6">Schwarz USA</h1>
-      <a href="early-access.html" class="text-lg text-yellow-300 hover:underline mb-8">
-        View Early Access
-      </a>
-      <a href="mailto:contact@schwarzusa.us" class="bg-white text-black px-6 py-3 rounded-full font-semibold hover:bg-gray-200 transition">
-        Contact Us
-      </a>
+  <body class="text-white font-sans">
+    <header class="relative w-full bg-black bg-opacity-80 text-sm px-6 py-4 flex items-center fixed top-0 left-0 right-0 z-50">
+      <a href="index.html" class="text-xl font-bold hover:underline">Schwarz USA</a>
+      <nav class="absolute left-1/2 transform -translate-x-1/2 space-x-6">
+        <a href="products.html" class="hover:underline">Products</a>
+        <a href="designs.html" class="hover:underline">Designs</a>
+        <a href="customize-card.html" class="hover:underline">Customize Card</a>
+        <a href="technologies.html" class="hover:underline">Technologies</a>
+      </nav>
+    </header>
+    <main class="pt-32 pb-20 px-6 text-center flex flex-col items-center">
+      <h1 class="text-4xl md:text-6xl font-bold mb-6">Upgrade Your Card. No Account Needed.</h1>
+      <div class="space-x-4">
+        <a href="products.html" class="bg-white text-black px-6 py-3 rounded-full font-semibold hover:bg-gray-200 transition">Pre-Made Designs</a>
+        <a href="customize-card.html" class="border border-white px-6 py-3 rounded-full font-semibold hover:bg-white hover:text-black transition">Design Your Card</a>
+      </div>
     </main>
-
-    <footer class="relative z-10 text-sm text-gray-500 mt-10 text-center p-4">
+    <footer class="text-sm text-gray-500 text-center p-4">
       &copy; <span id="year"></span> Schwarz USA. All rights reserved.
     </footer>
 <script>

--- a/products.html
+++ b/products.html
@@ -32,22 +32,33 @@
 
   <!-- Page content -->
   <main class="pt-28 px-6">
-    <h1 class="text-3xl font-semibold">Our Products</h1>
-    <p class="mt-4 text-gray-300">Explore our range of metal cards and accessories.</p>
-    <ul class="mt-6 grid gap-4 md:grid-cols-2 max-w-xl mx-auto">
-      <li class="bg-gray-700 p-4 rounded">Metal Business Card</li>
-      <li class="bg-gray-700 p-4 rounded">Engraved Dog Tag</li>
-      <li class="bg-gray-700 p-4 rounded">Custom Metal Card</li>
-      <li class="bg-gray-700 p-4 rounded flex flex-col space-y-2">
-        <img src="assets/Flag (Black-Brass).png" alt="American Flag metal card" class="rounded mb-2" />
-        <span class="text-xl font-semibold">American Flag</span>
-        <p class="text-gray-300">A black and brass metal card proudly emblazoned with the American flag.</p>
-        <div class="flex justify-between items-center">
-          <span class="text-lg font-bold">$99</span>
-          <button class="bg-orange-600 hover:bg-orange-700 px-4 py-2 rounded text-white">Order</button>
-        </div>
-      </li>
-    </ul>
+    <h1 class="text-3xl font-semibold text-center mb-6">Products</h1>
+    <div class="grid gap-8 sm:grid-cols-2 lg:grid-cols-3 max-w-5xl mx-auto">
+      <div class="bg-gray-800 p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
+        <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
+        <button class="order-btn bg-orange-600 hover:bg-orange-700 px-4 py-2 rounded text-white w-full" data-code="1A">Order</button>
+      </div>
+      <div class="bg-gray-800 p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
+        <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
+        <button class="order-btn bg-orange-600 hover:bg-orange-700 px-4 py-2 rounded text-white w-full" data-code="1B">Order</button>
+      </div>
+      <div class="bg-gray-800 p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
+        <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
+        <button class="order-btn bg-orange-600 hover:bg-orange-700 px-4 py-2 rounded text-white w-full" data-code="1C">Order</button>
+      </div>
+      <div class="bg-gray-800 p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
+        <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
+        <button class="order-btn bg-orange-600 hover:bg-orange-700 px-4 py-2 rounded text-white w-full" data-code="2A">Order</button>
+      </div>
+      <div class="bg-gray-800 p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
+        <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
+        <button class="order-btn bg-orange-600 hover:bg-orange-700 px-4 py-2 rounded text-white w-full" data-code="2B">Order</button>
+      </div>
+      <div class="bg-gray-800 p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
+        <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
+        <button class="order-btn bg-orange-600 hover:bg-orange-700 px-4 py-2 rounded text-white w-full" data-code="2C">Order</button>
+      </div>
+    </div>
   </main>
 
   <script>
@@ -58,5 +69,22 @@
       }
     });
   </script>
+  <div id="orderModal" class="hidden fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-50">
+    <div class="bg-white text-black p-6 rounded w-full max-w-md">
+      <div id="modalInfo">
+        <p class="mb-4">Here’s how it works:<br>1. You submit your shipping address.<br>2. We send you a return box for your old card.<br>3. We create and send your new card along with your old card.</p>
+        <button id="acknowledgeBtn" class="bg-gray-800 text-white px-4 py-2 rounded w-full">Acknowledge</button>
+      </div>
+      <form id="orderForm" class="hidden mt-4 space-y-4">
+        <input type="text" name="name" placeholder="Name" required class="w-full border p-2" />
+        <input type="email" name="email" placeholder="Email" required class="w-full border p-2" />
+        <input type="text" name="address" placeholder="Address" required class="w-full border p-2" />
+        <input type="text" name="design" id="designCode" readonly class="w-full border p-2" />
+        <textarea name="notes" placeholder="Additional notes" class="w-full border p-2"></textarea>
+        <button type="submit" class="bg-orange-600 text-white px-4 py-2 rounded w-full">Submit</button>
+      </form>
+    </div>
+  </div>
+  <script src="assets/order.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- modernize landing page with hero tagline
- add product gallery with placeholders
- showcase design grid
- restyle card customization interface
- add shared order modal logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872a6ca75ac832895e8bb2d946051d6