### PR TITLE
Improve custom card UI

### DIFF
--- a/customize-card.html
+++ b/customize-card.html
@@ -7,7 +7,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
     body {
-      background-color: #0d0d0d;
+      background-color: #1a1a1a;
       background-image: url('assets/bg-pattern.png');
       background-repeat: repeat;
       background-size: auto;
@@ -20,7 +20,7 @@
 </head>
 <body class="text-white font-sans">
   <!-- Navigation Bar -->
-   <header class="relative w-full bg-black bg-opacity-80 text-sm px-6 py-4 flex items-center fixed top-0 left-0 right-0 z-50">
+   <header class="relative w-full bg-[#1a1a1a] bg-opacity-90 text-sm px-6 py-4 flex items-center fixed top-0 left-0 right-0 z-50">
     <a href="index.html" class="text-xl font-bold hover:underline">Schwarz USA</a>
      <nav class="absolute left-1/2 transform -translate-x-1/2 space-x-6">
       <a href="products.html" class="hover:underline">Products</a>
@@ -37,6 +37,8 @@
       <div class="flex flex-col items-center space-y-4 md:w-1/2">
         <button onclick="nextBorder()" class="text-3xl">&#x2227;</button>
         <div id="cardPreview" class="w-64 h-40 relative flex items-center justify-center rounded border-4 overflow-hidden bg-black">
+          <button onclick="prevDesign()" class="absolute left-0 top-1/2 -translate-y-1/2 text-3xl">&#x2329;</button>
+          <button onclick="nextDesign()" class="absolute right-0 top-1/2 -translate-y-1/2 text-3xl">&#x232A;</button>
           <img id="designImage" src="assets/Placeholder_card.png" alt="Design preview" class="absolute inset-0 w-full h-full object-cover hidden" />
           <span id="designNumber" class="text-5xl"></span>
           <span id="borderLetter" class="absolute top-1 left-1 text-sm"></span>
@@ -44,17 +46,12 @@
         <button onclick="prevBorder()" class="text-3xl">&#x2228;</button>
       </div>
       <div class="flex flex-col items-center justify-center space-y-6 md:w-1/2 mt-8 md:mt-0">
-        <div class="flex items-center space-x-6">
-          <button onclick="prevDesign()" class="text-3xl">&#x2329;</button>
-          <span class="text-gray-400">Design</span>
-          <button onclick="nextDesign()" class="text-3xl">&#x232A;</button>
-        </div>
         <div class="flex space-x-6">
           <div id="color-black" class="color-option w-8 h-8 rounded-full bg-black border border-white cursor-pointer transition-transform" onclick="selectColor('black')"></div>
           <div id="color-white" class="color-option w-8 h-8 rounded-full bg-white border border-gray-400 cursor-pointer transition-transform" onclick="selectColor('white')"></div>
           <div id="color-gold" class="color-option w-8 h-8 rounded-full bg-yellow-500 border border-yellow-200 cursor-pointer transition-transform" onclick="selectColor('gold')"></div>
         </div>
-        <button class="order-btn bg-green-600 px-4 py-2 rounded text-white" data-code="">Order</button>
+        <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded" data-code="">Order</button>
       </div>
     </div>
   </main>
@@ -88,7 +85,10 @@
         }
         document.getElementById('borderLetter').textContent = borderLetters[borderIndex];
         const orderBtn = document.querySelector('.order-btn');
-        if (orderBtn) orderBtn.dataset.code = designNumbers[designIndex] + borderLetters[borderIndex];
+        if (orderBtn) {
+          const colorCode = selectedColorName.charAt(0).toUpperCase() + selectedColorName.slice(1);
+          orderBtn.dataset.code = colorCode + designNumbers[designIndex] + borderLetters[borderIndex];
+        }
       }
     function nextBorder() { borderIndex = (borderIndex + 1) % borderLetters.length; updatePreview(); }
     function prevBorder() { borderIndex = (borderIndex - 1 + borderLetters.length) % borderLetters.length; updatePreview(); }
@@ -107,7 +107,7 @@
   <div id="orderModal" class="hidden fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-50">
     <div class="bg-white text-black p-6 rounded w-full max-w-md">
       <div id="modalInfo">
-        <p class="mb-4">Here’s how it works:<br>1. You submit your order to orders@schwarzusa.us in the order form.<br>2. We send you a box to send us your old card.<br>3. We create and send your new card along with what is left of the old card (if requested).</p>
+        <p class="mb-4">Here’s how it works:<br>1. You submit your order to orders@schwarzusa.us in the order form.<br>2. We send you a box to send us your old card.<br>3. We create and send your new card along with what is left of the old card (if requested).<br><strong>NOTE:</strong> To transfer the chip to the new card, we partially submerge your old card in acetone to dissolve the plastic around the chip. Your old card will be unusable after this.</p>
         <button id="acknowledgeBtn" class="bg-gray-800 text-white px-4 py-2 rounded w-full">Acknowledge</button>
       </div>
       <form id="orderForm" class="hidden mt-4 space-y-4">
@@ -116,7 +116,7 @@
         <input type="text" name="address" placeholder="Address" required class="w-full border p-2" />
         <input type="text" name="design" id="designCode" readonly class="w-full border p-2" />
         <textarea name="notes" placeholder="Additional notes" class="w-full border p-2"></textarea>
-        <button type="submit" class="bg-orange-600 text-white px-4 py-2 rounded w-full">Submit</button>
+        <button type="submit" class="bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full">Submit</button>
       </form>
     </div>
   </div>

--- a/designs.html
+++ b/designs.html
@@ -7,7 +7,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
     body {
-      background-color: #0d0d0d;
+      background-color: #1a1a1a;
       background-image: url('assets/bg-pattern.png');
       background-repeat: repeat;
       background-size: auto;
@@ -20,7 +20,7 @@
 </head>
 <body class="text-white font-sans">
   <!-- Navigation Bar -->
-   <header class="relative w-full bg-black bg-opacity-80 text-sm px-6 py-4 flex items-center fixed top-0 left-0 right-0 z-50">
+   <header class="relative w-full bg-[#1a1a1a] bg-opacity-90 text-sm px-6 py-4 flex items-center fixed top-0 left-0 right-0 z-50">
     <a href="index.html" class="text-xl font-bold hover:underline">Schwarz USA</a>
      <nav class="absolute left-1/2 transform -translate-x-1/2 space-x-6">
       <a href="products.html" class="hover:underline">Products</a>
@@ -34,29 +34,29 @@
   <main class="pt-28 px-6">
     <h1 class="text-3xl font-semibold text-center mb-6">Designs</h1>
     <div class="grid gap-8 sm:grid-cols-2 lg:grid-cols-3 max-w-5xl mx-auto">
-      <div class="bg-gray-800 p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
+      <div class="bg-[#2d2d2d] p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
         <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
-        <button class="order-btn bg-orange-600 hover:bg-orange-700 px-4 py-2 rounded text-white w-full" data-code="B1">Order</button>
+        <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full" data-code="B1">Order</button>
       </div>
-      <div class="bg-gray-800 p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
+      <div class="bg-[#2d2d2d] p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
         <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
-        <button class="order-btn bg-orange-600 hover:bg-orange-700 px-4 py-2 rounded text-white w-full" data-code="B2">Order</button>
+        <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full" data-code="B2">Order</button>
       </div>
-      <div class="bg-gray-800 p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
+      <div class="bg-[#2d2d2d] p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
         <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
-        <button class="order-btn bg-orange-600 hover:bg-orange-700 px-4 py-2 rounded text-white w-full" data-code="B3">Order</button>
+        <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full" data-code="B3">Order</button>
       </div>
-      <div class="bg-gray-800 p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
+      <div class="bg-[#2d2d2d] p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
         <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
-        <button class="order-btn bg-orange-600 hover:bg-orange-700 px-4 py-2 rounded text-white w-full" data-code="B4">Order</button>
+        <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full" data-code="B4">Order</button>
       </div>
-      <div class="bg-gray-800 p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
+      <div class="bg-[#2d2d2d] p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
         <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
-        <button class="order-btn bg-orange-600 hover:bg-orange-700 px-4 py-2 rounded text-white w-full" data-code="B5">Order</button>
+        <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full" data-code="B5">Order</button>
       </div>
-      <div class="bg-gray-800 p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
+      <div class="bg-[#2d2d2d] p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
         <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
-        <button class="order-btn bg-orange-600 hover:bg-orange-700 px-4 py-2 rounded text-white w-full" data-code="B6">Order</button>
+        <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full" data-code="B6">Order</button>
       </div>
     </div>
   </main>
@@ -72,8 +72,8 @@
   <div id="orderModal" class="hidden fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-50">
     <div class="bg-white text-black p-6 rounded w-full max-w-md">
       <div id="modalInfo">
-        <p class="mb-4">Here’s how it works:<br>1. You submit your shipping address.<br>2. We send you a return box for your old card.<br>3. We create and send your new card along with your old card.</p>
-        <button id="acknowledgeBtn" class="bg-gray-800 text-white px-4 py-2 rounded w-full">Acknowledge</button>
+        <p class="mb-4">Here’s how it works:<br>1. You submit your shipping address.<br>2. We send you a return box for your old card.<br>3. We create and send your new card along with your old card.<br><strong>NOTE:</strong> To transfer the chip to the new card, we partially submerge your old card in acetone to dissolve the plastic around the chip. Your old card will be unusable after this.</p>
+        <button id="acknowledgeBtn" class="bg-[#e5e4e2] text-black px-4 py-2 rounded w-full">Acknowledge</button>
       </div>
       <form id="orderForm" class="hidden mt-4 space-y-4">
         <input type="text" name="name" placeholder="Name" required class="w-full border p-2" />
@@ -81,7 +81,7 @@
         <input type="text" name="address" placeholder="Address" required class="w-full border p-2" />
         <input type="text" name="design" id="designCode" readonly class="w-full border p-2" />
         <textarea name="notes" placeholder="Additional notes" class="w-full border p-2"></textarea>
-        <button type="submit" class="bg-orange-600 text-white px-4 py-2 rounded w-full">Submit</button>
+        <button type="submit" class="bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full">Submit</button>
       </form>
     </div>
   </div>

--- a/early-access.html
+++ b/early-access.html
@@ -6,8 +6,8 @@
     <title>Early Access - Schwarz USA</title>
     <script src="https://cdn.tailwindcss.com"></script>
   </head>
-  <body class="bg-black text-yellow-400 font-sans">
-     <header class="relative p-6 flex items-center text-sm">
+  <body class="bg-[#1a1a1a] text-yellow-400 font-sans">
+     <header class="relative p-6 flex items-center text-sm bg-[#1a1a1a]">
       <a href="index.html" class="font-bold hover:underline">Schwarz USA</a>
        <nav class="absolute left-1/2 transform -translate-x-1/2 space-x-4 text-gray-300">
         <a href="products.html" class="hover:underline">Products</a>
@@ -19,25 +19,25 @@
       <h2 class="text-2xl md:text-3xl font-semibold mb-2 text-white">Metal cards. Guaranteed.</h2>
       <p class="text-md md:text-xl text-gray-400 mb-10">Premium look, crafted on US soil.</p>
       <div class="grid md:grid-cols-2 gap-6 max-w-4xl mx-auto">
-        <div class="bg-gray-800 p-10 rounded">🪪</div>
-        <div class="bg-gray-800 p-10 rounded">🔲</div>
-        <div class="bg-gray-800 p-6 rounded text-left">
+        <div class="bg-[#2d2d2d] p-10 rounded">🪪</div>
+        <div class="bg-[#2d2d2d] p-10 rounded">🔲</div>
+        <div class="bg-[#2d2d2d] p-6 rounded text-left">
           <h3 class="text-white font-bold">Durable construction.</h3>
           <p class="text-sm text-gray-400">Crafted from premium metals, our cards deliver a distinct weight and feel.</p>
         </div>
-        <div class="bg-gray-800 p-6 rounded text-left">
+        <div class="bg-[#2d2d2d] p-6 rounded text-left">
           <h3 class="text-white font-bold">Custom designs.</h3>
           <p class="text-sm text-gray-400">Engrave your own artwork or select from signature templates.</p>
         </div>
-        <div class="bg-gray-800 p-6 rounded text-left">
+        <div class="bg-[#2d2d2d] p-6 rounded text-left">
           <h3 class="text-white font-bold">Fast turnaround.</h3>
           <p class="text-sm text-gray-400">Shipped from the U.S. with rapid fulfillment options.</p>
         </div>
-        <div class="bg-gray-800 p-10 rounded">🔺</div>
+        <div class="bg-[#2d2d2d] p-10 rounded">🔺</div>
       </div>
       <div class="mt-10">
         <p class="mb-4 text-white font-semibold">Upgrade to metal.</p>
-        <a href="mailto:contact@schwarzusa.us" class="bg-yellow-400 text-black px-6 py-2 rounded-full font-semibold hover:bg-yellow-300 transition">
+        <a href="mailto:contact@schwarzusa.us" class="bg-[#d4af37] text-black px-6 py-2 rounded-full font-semibold hover:bg-[#e0c94a] transition">
           Get Early Access
         </a>
       </div>

--- a/home.html
+++ b/home.html
@@ -7,7 +7,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
     body {
-      background-color: #0d0d0d;
+      background-color: #1a1a1a;
       background-image: url('assets/bg-pattern.png');
       background-repeat: repeat;
       background-size: auto;
@@ -20,7 +20,7 @@
 </head>
 <body class="text-white font-sans">
   <!-- Navigation Bar -->
-   <header class="relative w-full bg-black bg-opacity-80 text-sm px-6 py-4 flex items-center fixed top-0 left-0 right-0 z-50">
+   <header class="relative w-full bg-[#1a1a1a] bg-opacity-90 text-sm px-6 py-4 flex items-center fixed top-0 left-0 right-0 z-50">
     <a href="index.html" class="text-xl font-bold hover:underline">Schwarz USA</a>
      <nav class="absolute left-1/2 transform -translate-x-1/2 space-x-6">
       <a href="products.html" class="hover:underline nav-active">Products</a>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <style>
       body {
-        background-color: #0d0d0d;
+        background-color: #1a1a1a;
         background-image: url('assets/bg-pattern.png'); /* Make sure this matches your uploaded file */
         background-repeat: repeat;
         background-size: auto;
@@ -16,7 +16,7 @@
     </style>
   </head>
   <body class="text-white font-sans">
-    <header class="relative w-full bg-black bg-opacity-80 text-sm px-6 py-4 flex items-center fixed top-0 left-0 right-0 z-50">
+    <header class="relative w-full bg-[#1a1a1a] bg-opacity-90 text-sm px-6 py-4 flex items-center fixed top-0 left-0 right-0 z-50">
       <a href="index.html" class="text-xl font-bold hover:underline">Schwarz USA</a>
       <nav class="absolute left-1/2 transform -translate-x-1/2 space-x-6">
         <a href="products.html" class="hover:underline">Products</a>
@@ -28,8 +28,8 @@
     <main class="pt-32 pb-20 px-6 text-center flex flex-col items-center">
       <h1 class="text-4xl md:text-6xl font-bold mb-6">Upgrade Your Card. No Account Needed.</h1>
       <div class="space-x-4">
-        <a href="products.html" class="bg-white text-black px-6 py-3 rounded-full font-semibold hover:bg-gray-200 transition">Pre-Made Designs</a>
-        <a href="customize-card.html" class="border border-white px-6 py-3 rounded-full font-semibold hover:bg-white hover:text-black transition">Design Your Card</a>
+        <a href="products.html" class="bg-[#e5e4e2] text-black px-6 py-3 rounded-full font-semibold hover:bg-[#f2f2f2] transition">Pre-Made Designs</a>
+        <a href="customize-card.html" class="border border-[#d4af37] text-[#d4af37] px-6 py-3 rounded-full font-semibold hover:bg-[#d4af37] hover:text-black transition">Design Your Card</a>
       </div>
     </main>
     <footer class="text-sm text-gray-500 text-center p-4">

--- a/products.html
+++ b/products.html
@@ -7,7 +7,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
     body {
-      background-color: #0d0d0d;
+      background-color: #1a1a1a;
       background-image: url('assets/bg-pattern.png');
       background-repeat: repeat;
       background-size: auto;
@@ -20,7 +20,7 @@
 </head>
 <body class="text-white font-sans">
   <!-- Navigation Bar -->
-   <header class="relative w-full bg-black bg-opacity-80 text-sm px-6 py-4 flex items-center fixed top-0 left-0 right-0 z-50">
+   <header class="relative w-full bg-[#1a1a1a] bg-opacity-90 text-sm px-6 py-4 flex items-center fixed top-0 left-0 right-0 z-50">
     <a href="index.html" class="text-xl font-bold hover:underline">Schwarz USA</a>
      <nav class="absolute left-1/2 transform -translate-x-1/2 space-x-6">
       <a href="products.html" class="hover:underline nav-active">Products</a>
@@ -34,29 +34,29 @@
   <main class="pt-28 px-6">
     <h1 class="text-3xl font-semibold text-center mb-6">Products</h1>
     <div class="grid gap-8 sm:grid-cols-2 lg:grid-cols-3 max-w-5xl mx-auto">
-      <div class="bg-gray-800 p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
+      <div class="bg-[#2d2d2d] p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
         <img src="assets/Flag (Black-Brass).png" alt="Design" class="w-full rounded mb-4" />
-        <button class="order-btn bg-orange-600 hover:bg-orange-700 px-4 py-2 rounded text-white w-full" data-code="1A">Order</button>
+        <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full" data-code="1A">Order</button>
       </div>
-      <div class="bg-gray-800 p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
+      <div class="bg-[#2d2d2d] p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
         <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
-        <button class="order-btn bg-orange-600 hover:bg-orange-700 px-4 py-2 rounded text-white w-full" data-code="1B">Order</button>
+        <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full" data-code="1B">Order</button>
       </div>
-      <div class="bg-gray-800 p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
+      <div class="bg-[#2d2d2d] p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
         <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
-        <button class="order-btn bg-orange-600 hover:bg-orange-700 px-4 py-2 rounded text-white w-full" data-code="1C">Order</button>
+        <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full" data-code="1C">Order</button>
       </div>
-      <div class="bg-gray-800 p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
+      <div class="bg-[#2d2d2d] p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
         <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
-        <button class="order-btn bg-orange-600 hover:bg-orange-700 px-4 py-2 rounded text-white w-full" data-code="2A">Order</button>
+        <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full" data-code="2A">Order</button>
       </div>
-      <div class="bg-gray-800 p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
+      <div class="bg-[#2d2d2d] p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
         <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
-        <button class="order-btn bg-orange-600 hover:bg-orange-700 px-4 py-2 rounded text-white w-full" data-code="2B">Order</button>
+        <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full" data-code="2B">Order</button>
       </div>
-      <div class="bg-gray-800 p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
+      <div class="bg-[#2d2d2d] p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
         <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
-        <button class="order-btn bg-orange-600 hover:bg-orange-700 px-4 py-2 rounded text-white w-full" data-code="2C">Order</button>
+        <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full" data-code="2C">Order</button>
       </div>
     </div>
   </main>
@@ -72,8 +72,8 @@
   <div id="orderModal" class="hidden fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-50">
     <div class="bg-white text-black p-6 rounded w-full max-w-md">
       <div id="modalInfo">
-        <p class="mb-4">Here’s how it works:<br>1. You submit your shipping address.<br>2. We send you a return box for your old card.<br>3. We create and send your new card along with your old card.</p>
-        <button id="acknowledgeBtn" class="bg-gray-800 text-white px-4 py-2 rounded w-full">Acknowledge</button>
+        <p class="mb-4">Here’s how it works:<br>1. You submit your shipping address.<br>2. We send you a return box for your old card.<br>3. We create and send your new card along with your old card.<br><strong>NOTE:</strong> To transfer the chip to the new card, we partially submerge your old card in acetone to dissolve the plastic around the chip. Your old card will be unusable after this.</p>
+        <button id="acknowledgeBtn" class="bg-[#e5e4e2] text-black px-4 py-2 rounded w-full">Acknowledge</button>
       </div>
       <form id="orderForm" class="hidden mt-4 space-y-4">
         <input type="text" name="name" placeholder="Name" required class="w-full border p-2" />
@@ -81,7 +81,7 @@
         <input type="text" name="address" placeholder="Address" required class="w-full border p-2" />
         <input type="text" name="design" id="designCode" readonly class="w-full border p-2" />
         <textarea name="notes" placeholder="Additional notes" class="w-full border p-2"></textarea>
-        <button type="submit" class="bg-orange-600 text-white px-4 py-2 rounded w-full">Submit</button>
+        <button type="submit" class="bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full">Submit</button>
       </form>
     </div>
   </div>

--- a/technologies.html
+++ b/technologies.html
@@ -7,7 +7,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
     body {
-      background-color: #0d0d0d;
+      background-color: #1a1a1a;
       background-image: url('assets/bg-pattern.png');
       background-repeat: repeat;
       background-size: auto;
@@ -20,7 +20,7 @@
 </head>
 <body class="text-white font-sans">
   <!-- Navigation Bar -->
-   <header class="relative w-full bg-black bg-opacity-80 text-sm px-6 py-4 flex items-center fixed top-0 left-0 right-0 z-50">
+   <header class="relative w-full bg-[#1a1a1a] bg-opacity-90 text-sm px-6 py-4 flex items-center fixed top-0 left-0 right-0 z-50">
     <a href="index.html" class="text-xl font-bold hover:underline">Schwarz USA</a>
      <nav class="absolute left-1/2 transform -translate-x-1/2 space-x-6">
       <a href="products.html" class="hover:underline">Products</a>


### PR DESCRIPTION
## Summary
- tweak styling for a darker matte look with metallic accents
- move design arrows to sides of preview
- include card color in order code
- add chip transfer note to the ordering instructions

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6872b0427f0883289d2737e1b911d47c