### PR TITLE
Move nav arrows outside preview box

### DIFF
--- a/customize-card.html
+++ b/customize-card.html
@@ -35,20 +35,23 @@
     <h1 class="text-3xl font-semibold text-center">Customize Your Card</h1>
     <div class="flex flex-col md:flex-row md:space-x-10 w-full max-w-4xl">
       <div class="flex flex-col items-center space-y-4 md:w-1/2">
-        <button onclick="nextBorder()" class="text-3xl">&#x2227;</button>
-        <div id="cardPreview" class="w-64 h-40 relative flex items-center justify-center rounded border-4 overflow-hidden bg-black">
-          <button onclick="prevDesign()" class="absolute left-0 top-1/2 -translate-y-1/2 text-3xl z-10">&#x2329;</button>
-          <button onclick="nextDesign()" class="absolute right-0 top-1/2 -translate-y-1/2 text-3xl z-10">&#x232A;</button>
-          <object id="designSvg" data="assets/Test_Card.svg" type="image/svg+xml" class="absolute inset-0 w-full h-full pointer-events-none z-0"></object>
-          <span id="borderLetter" class="absolute top-1 left-1 text-sm"></span>
+        <!-- <button onclick="nextBorder()" class="text-3xl">&#x2227;</button> -->
+        <div class="flex items-center space-x-4">
+          <button onclick="prevDesign()" class="text-3xl">&#x2329;</button>
+          <div id="cardPreview" class="w-64 h-40 relative flex items-center justify-center rounded border-4 overflow-hidden bg-black">
+            <object id="designSvg" data="assets/Test_Card.svg" type="image/svg+xml" class="absolute inset-0 w-full h-full pointer-events-none z-0"></object>
+            <span id="borderLetter" class="absolute top-1 left-1 text-sm"></span>
+          </div>
+          <button onclick="nextDesign()" class="text-3xl">&#x232A;</button>
         </div>
-        <button onclick="prevBorder()" class="text-3xl">&#x2228;</button>
+        <!-- <button onclick="prevBorder()" class="text-3xl">&#x2228;</button> -->
       </div>
       <div class="flex flex-col items-center justify-center space-y-6 md:w-1/2 mt-8 md:mt-0">
         <div class="flex space-x-6">
           <div id="color-black" class="color-option w-8 h-8 rounded-full bg-black border border-white cursor-pointer transition-transform" onclick="selectColor('black')"></div>
           <div id="color-white" class="color-option w-8 h-8 rounded-full bg-white border border-gray-400 cursor-pointer transition-transform" onclick="selectColor('white')"></div>
           <div id="color-gold" class="color-option w-8 h-8 rounded-full bg-yellow-500 border border-yellow-200 cursor-pointer transition-transform" onclick="selectColor('gold')"></div>
+          <div id="color-blackbrass" class="color-option w-8 h-8 rounded-full bg-black border cursor-pointer transition-transform" style="border-color:#b08d57" onclick="selectColor('blackbrass')"></div>
         </div>
         <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded" data-code="">Order</button>
       </div>
@@ -85,8 +88,20 @@
           const svgDoc = designSvgEl.contentDocument;
           if (svgDoc) {
             const cardShape = svgDoc.getElementById('card-fill');
+            let designColor;
+            if (selectedColorName === 'blackbrass') {
+              designColor = '#b08d57'; // brass
+            } else if (selectedColorName === 'black') {
+              designColor = '#d0d0d0'; // stainless steel
+            } else if (selectedColorName === 'white') {
+              designColor = '#d0d0d0'; // stainless steel
+            } else if (selectedColorName === 'gold') {
+              designColor = '#d0d0d0'; // stainless steel
+            } else {
+              designColor = '#d0d0d0';
+            }
             if (cardShape) {
-              cardShape.setAttribute('fill', '#b08d57');
+              cardShape.setAttribute('fill', designColor);
             }
           }
         };
@@ -94,8 +109,19 @@
 
         const orderBtn = document.querySelector('.order-btn');
         if (orderBtn) {
-          const colorCode = selectedColorName.charAt(0).toUpperCase() + selectedColorName.slice(1);
-          orderBtn.dataset.code = colorCode + design.id + borderLetters[borderIndex];
+          let colorCode;
+            if (selectedColorName === 'blackbrass') {
+              colorCode = 'BLKBRS';
+            } else if (selectedColorName === 'black') {
+              colorCode = 'Black';
+            } else if (selectedColorName === 'white') {
+              colorCode = 'White';
+            } else if (selectedColorName === 'gold') {
+              colorCode = 'Gold';
+            } else {
+              colorCode = selectedColorName;
+            }
+            orderBtn.dataset.code = colorCode + design.id + borderLetters[borderIndex];
         }
       }
     function nextBorder() { borderIndex = (borderIndex + 1) % borderLetters.length; updatePreview(); }
@@ -104,7 +130,17 @@
     function prevDesign() { designIndex = (designIndex - 1 + designs.length) % designs.length; updatePreview(); }
     function selectColor(color) {
       selectedColorName = color;
-      selectedColor = color === 'gold' ? '#d4af37' : color;
+        if (color === "gold") {
+          selectedColor = "#d4af37";
+        } else if (color === "blackbrass") {
+          selectedColor = "black";
+        } else if (color === "black") {
+          selectedColor = "black";
+        } else if (color === "white") {
+          selectedColor = "white";
+        } else {
+          selectedColor = color;
+        }
       document.querySelectorAll('.color-option').forEach(el => el.classList.remove('ring-4','scale-110'));
       const el = document.getElementById('color-' + color);
       if (el) { el.classList.add('ring-4','scale-110'); }


### PR DESCRIPTION
## Summary
- move design navigation arrows outside of preview box
- comment out border navigation arrows
- add BlackBrass card option
- tie design colors to card colors

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6873b7ff1248832886ae4ba52fe45f7e