### PR TITLE
Improve responsiveness and product layouts

### DIFF
--- a/customize-card.html
+++ b/customize-card.html
@@ -31,14 +31,14 @@
   </header>
 
   <!-- Page content -->
-  <main class="pt-28 px-6 flex flex-col items-center space-y-8">
+  <main class="pt-28 px-6 flex flex-col items-center space-y-8 min-h-screen justify-center">
     <h1 class="text-3xl font-semibold text-center">Customize Your Card</h1>
-    <div class="flex flex-col md:flex-row md:space-x-10 w-full max-w-4xl">
+    <div class="flex flex-col md:flex-row md:space-x-10 w-full max-w-5xl">
       <div class="flex flex-col items-center space-y-4 md:w-1/2">
         <!-- <button onclick="nextBorder()" class="text-3xl">&#x2227;</button> -->
         <div class="flex items-center space-x-4">
           <button onclick="prevDesign()" class="text-3xl">&#x2329;</button>
-          <div id="cardPreview" class="w-64 h-40 relative flex items-center justify-center rounded border-4 overflow-hidden bg-black">
+          <div id="cardPreview" class="w-80 h-52 relative flex items-center justify-center rounded border-4 overflow-hidden bg-black">
             <object id="designSvg" data="assets/Test_Card.svg" type="image/svg+xml" class="absolute inset-0 w-full h-full pointer-events-none z-0"></object>
             <span id="borderLetter" class="absolute top-1 left-1 text-sm"></span>
           </div>

--- a/designs.html
+++ b/designs.html
@@ -33,30 +33,48 @@
   <!-- Page content -->
   <main class="pt-28 px-6">
     <h1 class="text-3xl font-semibold text-center mb-6">Designs</h1>
-    <div class="grid gap-8 sm:grid-cols-2 lg:grid-cols-3 max-w-5xl mx-auto">
-      <div class="bg-[#2d2d2d] p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
-        <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
-        <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full" data-code="B1">Order</button>
+    <div class="space-y-12 max-w-5xl mx-auto">
+      <div class="flex flex-col md:flex-row-reverse items-center md:space-x-10 md:space-x-reverse bg-[#2d2d2d] p-4 rounded">
+        <img src="assets/Placeholder_card.png" alt="Design" class="w-full md:w-1/2 rounded" />
+        <div class="mt-4 md:mt-0 md:w-1/2 text-center md:text-left">
+          <p class="mb-4">Description for design B1.</p>
+          <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded" data-code="B1">Order</button>
+        </div>
       </div>
-      <div class="bg-[#2d2d2d] p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
-        <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
-        <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full" data-code="B2">Order</button>
+      <div class="flex flex-col md:flex-row items-center md:space-x-10 bg-[#2d2d2d] p-4 rounded">
+        <img src="assets/Placeholder_card.png" alt="Design" class="w-full md:w-1/2 rounded" />
+        <div class="mt-4 md:mt-0 md:w-1/2 text-center md:text-left">
+          <p class="mb-4">Description for design B2.</p>
+          <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded" data-code="B2">Order</button>
+        </div>
       </div>
-      <div class="bg-[#2d2d2d] p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
-        <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
-        <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full" data-code="B3">Order</button>
+      <div class="flex flex-col md:flex-row-reverse items-center md:space-x-10 md:space-x-reverse bg-[#2d2d2d] p-4 rounded">
+        <img src="assets/Placeholder_card.png" alt="Design" class="w-full md:w-1/2 rounded" />
+        <div class="mt-4 md:mt-0 md:w-1/2 text-center md:text-left">
+          <p class="mb-4">Description for design B3.</p>
+          <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded" data-code="B3">Order</button>
+        </div>
       </div>
-      <div class="bg-[#2d2d2d] p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
-        <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
-        <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full" data-code="B4">Order</button>
+      <div class="flex flex-col md:flex-row items-center md:space-x-10 bg-[#2d2d2d] p-4 rounded">
+        <img src="assets/Placeholder_card.png" alt="Design" class="w-full md:w-1/2 rounded" />
+        <div class="mt-4 md:mt-0 md:w-1/2 text-center md:text-left">
+          <p class="mb-4">Description for design B4.</p>
+          <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded" data-code="B4">Order</button>
+        </div>
       </div>
-      <div class="bg-[#2d2d2d] p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
-        <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
-        <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full" data-code="B5">Order</button>
+      <div class="flex flex-col md:flex-row-reverse items-center md:space-x-10 md:space-x-reverse bg-[#2d2d2d] p-4 rounded">
+        <img src="assets/Placeholder_card.png" alt="Design" class="w-full md:w-1/2 rounded" />
+        <div class="mt-4 md:mt-0 md:w-1/2 text-center md:text-left">
+          <p class="mb-4">Description for design B5.</p>
+          <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded" data-code="B5">Order</button>
+        </div>
       </div>
-      <div class="bg-[#2d2d2d] p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
-        <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
-        <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full" data-code="B6">Order</button>
+      <div class="flex flex-col md:flex-row items-center md:space-x-10 bg-[#2d2d2d] p-4 rounded">
+        <img src="assets/Placeholder_card.png" alt="Design" class="w-full md:w-1/2 rounded" />
+        <div class="mt-4 md:mt-0 md:w-1/2 text-center md:text-left">
+          <p class="mb-4">Description for design B6.</p>
+          <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded" data-code="B6">Order</button>
+        </div>
       </div>
     </div>
   </main>

--- a/early-access.html
+++ b/early-access.html
@@ -15,7 +15,7 @@
         <a href="customize-card.html" class="hover:underline">Customize Card</a>
       </nav>
     </header>
-    <main class="px-6 md:px-20 py-10 text-center">
+    <main class="px-6 md:px-20 py-10 text-center min-h-screen flex flex-col justify-center">
       <h2 class="text-2xl md:text-3xl font-semibold mb-2 text-white">Metal cards. Guaranteed.</h2>
       <p class="text-md md:text-xl text-gray-400 mb-10">Premium look, crafted on US soil.</p>
       <div class="grid md:grid-cols-2 gap-6 max-w-4xl mx-auto">

--- a/home.html
+++ b/home.html
@@ -31,7 +31,7 @@
   </header>
 
   <!-- Page content -->
-  <main class="pt-28 px-6">
+  <main class="pt-28 px-6 min-h-screen flex flex-col justify-center">
     <h1 class="text-3xl font-semibold">Welcome to Schwarz USA</h1>
     <p class="mt-4 text-gray-300">This will become the future homepage.</p>
   </main>

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         <a href="technologies.html" class="hover:underline">Technologies</a>
       </nav>
     </header>
-    <main class="pt-32 pb-20 px-6 text-center flex flex-col items-center">
+    <main class="pt-32 pb-20 px-6 text-center flex flex-col items-center min-h-screen justify-center">
       <h1 class="text-4xl md:text-6xl font-bold mb-6">Upgrade Your Card. No Account Needed.</h1>
       <div class="space-x-4">
         <a href="products.html" class="bg-[#e5e4e2] text-black px-6 py-3 rounded-full font-semibold hover:bg-[#f2f2f2] transition">Pre-Made Designs</a>

--- a/products.html
+++ b/products.html
@@ -33,30 +33,48 @@
   <!-- Page content -->
   <main class="pt-28 px-6">
     <h1 class="text-3xl font-semibold text-center mb-6">Products</h1>
-    <div class="grid gap-8 sm:grid-cols-2 lg:grid-cols-3 max-w-5xl mx-auto">
-      <div class="bg-[#2d2d2d] p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
-        <img src="assets/Flag (Black-Brass).png" alt="Design" class="w-full rounded mb-4" />
-        <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full" data-code="1A">Order</button>
+    <div class="space-y-12 max-w-5xl mx-auto">
+      <div class="flex flex-col md:flex-row-reverse items-center md:space-x-10 md:space-x-reverse bg-[#2d2d2d] p-4 rounded">
+        <img src="assets/Flag (Black-Brass).png" alt="Design" class="w-full md:w-1/2 rounded" />
+        <div class="mt-4 md:mt-0 md:w-1/2 text-center md:text-left">
+          <p class="mb-4">Description for product 1A.</p>
+          <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded" data-code="1A">Order</button>
+        </div>
       </div>
-      <div class="bg-[#2d2d2d] p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
-        <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
-        <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full" data-code="1B">Order</button>
+      <div class="flex flex-col md:flex-row items-center md:space-x-10 bg-[#2d2d2d] p-4 rounded">
+        <img src="assets/Placeholder_card.png" alt="Design" class="w-full md:w-1/2 rounded" />
+        <div class="mt-4 md:mt-0 md:w-1/2 text-center md:text-left">
+          <p class="mb-4">Description for product 1B.</p>
+          <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded" data-code="1B">Order</button>
+        </div>
       </div>
-      <div class="bg-[#2d2d2d] p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
-        <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
-        <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full" data-code="1C">Order</button>
+      <div class="flex flex-col md:flex-row-reverse items-center md:space-x-10 md:space-x-reverse bg-[#2d2d2d] p-4 rounded">
+        <img src="assets/Placeholder_card.png" alt="Design" class="w-full md:w-1/2 rounded" />
+        <div class="mt-4 md:mt-0 md:w-1/2 text-center md:text-left">
+          <p class="mb-4">Description for product 1C.</p>
+          <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded" data-code="1C">Order</button>
+        </div>
       </div>
-      <div class="bg-[#2d2d2d] p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
-        <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
-        <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full" data-code="2A">Order</button>
+      <div class="flex flex-col md:flex-row items-center md:space-x-10 bg-[#2d2d2d] p-4 rounded">
+        <img src="assets/Placeholder_card.png" alt="Design" class="w-full md:w-1/2 rounded" />
+        <div class="mt-4 md:mt-0 md:w-1/2 text-center md:text-left">
+          <p class="mb-4">Description for product 2A.</p>
+          <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded" data-code="2A">Order</button>
+        </div>
       </div>
-      <div class="bg-[#2d2d2d] p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
-        <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
-        <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full" data-code="2B">Order</button>
+      <div class="flex flex-col md:flex-row-reverse items-center md:space-x-10 md:space-x-reverse bg-[#2d2d2d] p-4 rounded">
+        <img src="assets/Placeholder_card.png" alt="Design" class="w-full md:w-1/2 rounded" />
+        <div class="mt-4 md:mt-0 md:w-1/2 text-center md:text-left">
+          <p class="mb-4">Description for product 2B.</p>
+          <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded" data-code="2B">Order</button>
+        </div>
       </div>
-      <div class="bg-[#2d2d2d] p-4 rounded shadow hover:shadow-lg transition flex flex-col items-center">
-        <img src="assets/Placeholder_card.png" alt="Design" class="w-full rounded mb-4" />
-        <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full" data-code="2C">Order</button>
+      <div class="flex flex-col md:flex-row items-center md:space-x-10 bg-[#2d2d2d] p-4 rounded">
+        <img src="assets/Placeholder_card.png" alt="Design" class="w-full md:w-1/2 rounded" />
+        <div class="mt-4 md:mt-0 md:w-1/2 text-center md:text-left">
+          <p class="mb-4">Description for product 2C.</p>
+          <button class="order-btn bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded" data-code="2C">Order</button>
+        </div>
       </div>
     </div>
   </main>

--- a/technologies.html
+++ b/technologies.html
@@ -31,7 +31,7 @@
   </header>
 
   <!-- Page content -->
-  <main class="pt-28 px-6">
+  <main class="pt-28 px-6 min-h-screen flex flex-col justify-center">
     <h1 class="text-3xl font-semibold">Our Technologies</h1>
     <p class="mt-4 text-gray-300">Learn about the materials and processes we use.</p>
   </main>


### PR DESCRIPTION
## Summary
- make main sections fill the screen on most pages
- enlarge customize card preview
- redesign product and design listings to alternate image positions
- tweak pages for better mobile responsiveness

## Testing
- `tidy -qe index.html designs.html products.html customize-card.html home.html early-access.html technologies.html`

------
https://chatgpt.com/codex/tasks/task_e_6873e7e4cd7c83289bc1173fec0ebdb9