### PR TITLE
Implement mobile dropdown navigation

### DIFF
--- a/customize-card.html
+++ b/customize-card.html
@@ -21,8 +21,14 @@
 <body class="text-white font-sans">
   <!-- Navigation Bar -->
    <header class="relative w-full bg-[#1a1a1a] bg-opacity-90 text-sm px-6 py-4 flex items-center fixed top-0 left-0 right-0 z-50">
-    <a href="index.html" class="text-xl font-bold hover:underline">Schwarz USA</a>
-     <nav class="absolute left-1/2 transform -translate-x-1/2 space-x-6">
+    <button id="menuBtn" class="flex items-center space-x-2 md:hidden">
+      <span class="text-xl font-bold">Schwarz USA</span>
+      <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+      </svg>
+    </button>
+    <a href="index.html" class="text-xl font-bold hover:underline hidden md:block">Schwarz USA</a>
+     <nav id="navMenu" class="absolute left-0 right-0 top-full bg-[#1a1a1a] bg-opacity-90 text-center py-2 hidden flex-col space-y-2 md:flex md:flex-row md:space-x-6 md:space-y-0 md:static md:py-0 md:bg-transparent md:transform md:-translate-x-1/2 md:left-1/2">
       <a href="products.html" class="hover:underline">Products</a>
       <a href="designs.html" class="hover:underline">Designs</a>
       <a href="customize-card.html" class="hover:underline nav-active">Customize Card</a>
@@ -170,6 +176,9 @@
   document.addEventListener('DOMContentLoaded', () => {
     // initialize preview with the default color
     selectColor('black');
+  });
+  document.getElementById('menuBtn').addEventListener('click', function() {
+    document.getElementById('navMenu').classList.toggle('hidden');
   });
   </script>
   <div id="orderModal" class="hidden fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-50">

--- a/designs.html
+++ b/designs.html
@@ -21,8 +21,14 @@
 <body class="text-white font-sans">
   <!-- Navigation Bar -->
    <header class="relative w-full bg-[#1a1a1a] bg-opacity-90 text-sm px-6 py-4 flex items-center fixed top-0 left-0 right-0 z-50">
-    <a href="index.html" class="text-xl font-bold hover:underline">Schwarz USA</a>
-     <nav class="absolute left-1/2 transform -translate-x-1/2 space-x-6">
+    <button id="menuBtn" class="flex items-center space-x-2 md:hidden">
+      <span class="text-xl font-bold">Schwarz USA</span>
+      <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+      </svg>
+    </button>
+    <a href="index.html" class="text-xl font-bold hover:underline hidden md:block">Schwarz USA</a>
+     <nav id="navMenu" class="absolute left-0 right-0 top-full bg-[#1a1a1a] bg-opacity-90 text-center py-2 hidden flex-col space-y-2 md:flex md:flex-row md:space-x-6 md:space-y-0 md:static md:py-0 md:bg-transparent md:transform md:-translate-x-1/2 md:left-1/2">
       <a href="products.html" class="hover:underline">Products</a>
       <a href="designs.html" class="hover:underline nav-active">Designs</a>
       <a href="customize-card.html" class="hover:underline">Customize Card</a>
@@ -85,6 +91,9 @@
       if (e.key === 'Enter') {
         window.location.href = 'home.html';
       }
+    });
+    document.getElementById('menuBtn').addEventListener('click', function() {
+      document.getElementById('navMenu').classList.toggle('hidden');
     });
   </script>
   <div id="orderModal" class="hidden fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-50">

--- a/early-access.html
+++ b/early-access.html
@@ -7,9 +7,15 @@
     <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body class="bg-[#1a1a1a] text-yellow-400 font-sans">
-     <header class="relative p-6 flex items-center text-sm bg-[#1a1a1a]">
-      <a href="index.html" class="font-bold hover:underline">Schwarz USA</a>
-       <nav class="absolute left-1/2 transform -translate-x-1/2 space-x-4 text-gray-300">
+    <header class="relative p-6 flex items-center text-sm bg-[#1a1a1a]">
+      <button id="menuBtn" class="flex items-center space-x-2 md:hidden">
+        <span class="font-bold">Schwarz USA</span>
+        <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
+      <a href="index.html" class="font-bold hover:underline hidden md:block">Schwarz USA</a>
+       <nav id="navMenu" class="absolute left-0 right-0 top-full bg-[#1a1a1a] bg-opacity-90 text-center py-2 hidden flex-col space-y-2 md:flex md:flex-row md:space-x-4 md:space-y-0 md:static md:bg-transparent md:top-auto md:transform md:-translate-x-1/2 md:left-1/2">
         <a href="products.html" class="hover:underline">Products</a>
         <a href="designs.html" class="hover:underline">Designs</a>
         <a href="customize-card.html" class="hover:underline">Customize Card</a>
@@ -45,8 +51,11 @@
     <footer class="text-sm text-gray-500 mt-20 text-center p-4">
       &copy; <span id="year"></span> Schwarz USA
     </footer>
-    <script>
+  <script>
       document.getElementById("year").textContent = new Date().getFullYear();
-    </script>
+      document.getElementById('menuBtn').addEventListener('click', function() {
+        document.getElementById('navMenu').classList.toggle('hidden');
+      });
+  </script>
   </body>
 </html>

--- a/home.html
+++ b/home.html
@@ -21,8 +21,14 @@
 <body class="text-white font-sans">
   <!-- Navigation Bar -->
    <header class="relative w-full bg-[#1a1a1a] bg-opacity-90 text-sm px-6 py-4 flex items-center fixed top-0 left-0 right-0 z-50">
-    <a href="index.html" class="text-xl font-bold hover:underline">Schwarz USA</a>
-     <nav class="absolute left-1/2 transform -translate-x-1/2 space-x-6">
+    <button id="menuBtn" class="flex items-center space-x-2 md:hidden">
+      <span class="text-xl font-bold">Schwarz USA</span>
+      <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+      </svg>
+    </button>
+    <a href="index.html" class="text-xl font-bold hover:underline hidden md:block">Schwarz USA</a>
+     <nav id="navMenu" class="absolute left-0 right-0 top-full bg-[#1a1a1a] bg-opacity-90 text-center py-2 hidden flex-col space-y-2 md:flex md:flex-row md:space-x-6 md:space-y-0 md:static md:py-0 md:bg-transparent md:transform md:-translate-x-1/2 md:left-1/2">
       <a href="products.html" class="hover:underline nav-active">Products</a>
       <a href="designs.html" class="hover:underline">Designs</a>
       <a href="customize-card.html" class="hover:underline">Customize Card</a>
@@ -43,6 +49,9 @@
       if (e.key === 'Enter' && tag !== 'input' && tag !== 'textarea') {
         window.location.href = 'home.html';
       }
+    });
+    document.getElementById('menuBtn').addEventListener('click', function() {
+      document.getElementById('navMenu').classList.toggle('hidden');
     });
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -17,8 +17,14 @@
   </head>
   <body class="text-white font-sans">
     <header class="relative w-full bg-[#1a1a1a] bg-opacity-90 text-sm px-6 py-4 flex items-center fixed top-0 left-0 right-0 z-50">
-      <a href="index.html" class="text-xl font-bold hover:underline">Schwarz USA</a>
-      <nav class="absolute left-1/2 transform -translate-x-1/2 space-x-6">
+      <button id="menuBtn" class="flex items-center space-x-2 md:hidden">
+        <span class="text-xl font-bold">Schwarz USA</span>
+        <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
+      <a href="index.html" class="text-xl font-bold hover:underline hidden md:block">Schwarz USA</a>
+      <nav id="navMenu" class="absolute left-0 right-0 top-full bg-[#1a1a1a] bg-opacity-90 text-center py-2 hidden flex-col space-y-2 md:flex md:flex-row md:space-x-6 md:space-y-0 md:static md:py-0 md:bg-transparent md:transform md:-translate-x-1/2 md:left-1/2">
         <a href="products.html" class="hover:underline">Products</a>
         <a href="designs.html" class="hover:underline">Designs</a>
         <a href="customize-card.html" class="hover:underline">Customize Card</a>
@@ -27,20 +33,23 @@
     </header>
     <main class="pt-32 pb-20 px-6 text-center flex flex-col items-center min-h-screen justify-center">
       <h1 class="text-4xl md:text-6xl font-bold mb-6">Upgrade Your Card. No Account Needed.</h1>
-      <div class="space-x-4">
+      <div class="flex flex-col space-y-4 md:flex-row md:space-y-0 md:space-x-4">
         <a href="products.html" class="bg-[#e5e4e2] text-black px-6 py-3 rounded-full font-semibold hover:bg-[#f2f2f2] transition">Pre-Made Designs</a>
         <a href="customize-card.html" class="border border-[#d4af37] text-[#d4af37] px-6 py-3 rounded-full font-semibold hover:bg-[#d4af37] hover:text-black transition">Design Your Card</a>
       </div>
     </main>
     <footer class="text-sm text-gray-500 text-center p-4">
       &copy; <span id="year"></span> Schwarz USA. All rights reserved.
-    </footer>
+</footer>
 <script>
   document.addEventListener('keydown', function(e) {
     const tag = e.target.tagName.toLowerCase();
     if (e.key === 'Enter' && tag !== 'input' && tag !== 'textarea') {
       window.location.href = 'home.html';
     }
+  });
+  document.getElementById('menuBtn').addEventListener('click', function() {
+    document.getElementById('navMenu').classList.toggle('hidden');
   });
 </script>
 

--- a/products.html
+++ b/products.html
@@ -21,8 +21,14 @@
 <body class="text-white font-sans">
   <!-- Navigation Bar -->
    <header class="relative w-full bg-[#1a1a1a] bg-opacity-90 text-sm px-6 py-4 flex items-center fixed top-0 left-0 right-0 z-50">
-    <a href="index.html" class="text-xl font-bold hover:underline">Schwarz USA</a>
-     <nav class="absolute left-1/2 transform -translate-x-1/2 space-x-6">
+    <button id="menuBtn" class="flex items-center space-x-2 md:hidden">
+      <span class="text-xl font-bold">Schwarz USA</span>
+      <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+      </svg>
+    </button>
+    <a href="index.html" class="text-xl font-bold hover:underline hidden md:block">Schwarz USA</a>
+     <nav id="navMenu" class="absolute left-0 right-0 top-full bg-[#1a1a1a] bg-opacity-90 text-center py-2 hidden flex-col space-y-2 md:flex md:flex-row md:space-x-6 md:space-y-0 md:static md:py-0 md:bg-transparent md:transform md:-translate-x-1/2 md:left-1/2">
       <a href="products.html" class="hover:underline nav-active">Products</a>
       <a href="designs.html" class="hover:underline">Designs</a>
       <a href="customize-card.html" class="hover:underline">Customize Card</a>
@@ -85,6 +91,9 @@
       if (e.key === 'Enter') {
         window.location.href = 'home.html';
       }
+    });
+    document.getElementById('menuBtn').addEventListener('click', function() {
+      document.getElementById('navMenu').classList.toggle('hidden');
     });
   </script>
   <div id="orderModal" class="hidden fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-50">

--- a/technologies.html
+++ b/technologies.html
@@ -21,8 +21,14 @@
 <body class="text-white font-sans">
   <!-- Navigation Bar -->
    <header class="relative w-full bg-[#1a1a1a] bg-opacity-90 text-sm px-6 py-4 flex items-center fixed top-0 left-0 right-0 z-50">
-    <a href="index.html" class="text-xl font-bold hover:underline">Schwarz USA</a>
-     <nav class="absolute left-1/2 transform -translate-x-1/2 space-x-6">
+    <button id="menuBtn" class="flex items-center space-x-2 md:hidden">
+      <span class="text-xl font-bold">Schwarz USA</span>
+      <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+      </svg>
+    </button>
+    <a href="index.html" class="text-xl font-bold hover:underline hidden md:block">Schwarz USA</a>
+     <nav id="navMenu" class="absolute left-0 right-0 top-full bg-[#1a1a1a] bg-opacity-90 text-center py-2 hidden flex-col space-y-2 md:flex md:flex-row md:space-x-6 md:space-y-0 md:static md:py-0 md:bg-transparent md:transform md:-translate-x-1/2 md:left-1/2">
       <a href="products.html" class="hover:underline">Products</a>
       <a href="designs.html" class="hover:underline">Designs</a>
       <a href="customize-card.html" class="hover:underline">Customize Card</a>
@@ -42,6 +48,9 @@
       if (e.key === 'Enter') {
         window.location.href = 'home.html';
       }
+    });
+    document.getElementById('menuBtn').addEventListener('click', function() {
+      document.getElementById('navMenu').classList.toggle('hidden');
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add dropdown navigation triggered from "Schwarz USA" with hamburger icon
- stack landing page buttons vertically on small screens
- apply mobile menu across all pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68740ec6edd08328a06e6c268d254e17