### PR TITLE
Resize card preview

### DIFF
--- a/customize-card.html
+++ b/customize-card.html
@@ -44,7 +44,7 @@
         <!-- <button onclick="nextBorder()" class="text-3xl">&#x2227;</button> -->
         <div class="flex items-center space-x-4">
           <button onclick="prevDesign()" class="text-3xl">&#x2329;</button>
-          <div id="cardPreview" class="w-[20vw] h-[12.6vw] relative flex items-center justify-center rounded border-4 overflow-hidden bg-black">
+          <div id="cardPreview" class="w-[80vw] h-[50.4vw] md:w-[50vw] md:h-[31.5vw] relative flex items-center justify-center rounded border-4 overflow-hidden bg-black">
             <object id="designSvg" data="assets/Test_Card.svg" type="image/svg+xml" class="absolute inset-0 w-full h-full pointer-events-none z-0"></object>
             <span id="borderLetter" class="absolute top-1 left-1 text-sm"></span>
           </div>


### PR DESCRIPTION
## Summary
- make the customize card preview fill half the viewport on desktop and most of it on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874be3404588328b9f0f21e0f968d24