### PR TITLE
Fix design navigation

### DIFF
--- a/customize-card.html
+++ b/customize-card.html
@@ -43,12 +43,12 @@
       <div class="flex flex-col items-center space-y-4 md:w-1/2">
         <!-- <button onclick="nextBorder()" class="text-3xl">&#x2227;</button> -->
         <div class="flex items-center space-x-4">
-          <button id="prevDesignBtn" class="text-3xl">&#x2329;</button>
+          <button id="prevDesignBtn" type="button" class="text-3xl" onclick="prevDesign()">&#x2329;</button>
           <div id="cardPreview" class="w-[80vw] h-[50.4vw] md:w-[50vw] md:h-[31.5vw] relative flex items-center justify-center rounded border-4 overflow-hidden bg-black">
             <object id="designSvg" data="assets/Test_Card.svg" type="image/svg+xml" class="absolute inset-0 w-full h-full pointer-events-none z-0"></object>
             <span id="borderLetter" class="absolute top-1 left-1 text-sm"></span>
           </div>
-          <button id="nextDesignBtn" class="text-3xl">&#x232A;</button>
+          <button id="nextDesignBtn" type="button" class="text-3xl" onclick="nextDesign()">&#x232A;</button>
         </div>
         <!-- <button onclick="prevBorder()" class="text-3xl">&#x2228;</button> -->
       </div>


### PR DESCRIPTION
## Summary
- ensure right arrow button selects the next design
- make both arrow buttons `type="button"` and add inline handlers as a fallback

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874f1a7737c832883d61ab8e4202dc1