### PR TITLE
Adjust control layout on customize card page

### DIFF
--- a/customize-card.html
+++ b/customize-card.html
@@ -39,8 +39,8 @@
   <!-- Page content -->
   <main class="pt-28 px-6 flex flex-col items-center space-y-8 min-h-screen justify-center">
     <h1 class="text-3xl font-semibold text-center">Customize Your Card</h1>
-    <div class="flex flex-col md:flex-row md:space-x-10 w-full max-w-5xl">
-      <div class="flex flex-col items-center space-y-4 md:w-1/2">
+    <div class="flex flex-col w-full max-w-5xl items-center space-y-6">
+      <div class="flex flex-col items-center space-y-4 w-full">
         <!-- <button onclick="nextBorder()" class="text-3xl">&#x2227;</button> -->
         <div class="flex items-center space-x-4">
           <button id="prevDesignBtn" type="button" class="text-3xl" onclick="prevDesign()">&#x2329;</button>
@@ -52,7 +52,7 @@
         </div>
         <!-- <button onclick="prevBorder()" class="text-3xl">&#x2228;</button> -->
       </div>
-      <div class="flex flex-col items-center justify-center space-y-6 md:w-1/2 mt-8 md:mt-0">
+      <div class="flex flex-col items-center justify-center space-y-6 w-full">
         <div class="flex space-x-6">
           <div id="color-black" class="color-option w-8 h-8 rounded-full bg-black border border-white cursor-pointer transition-transform" onclick="selectColor('black')"></div>
           <div id="color-white" class="color-option w-8 h-8 rounded-full bg-white border border-gray-400 cursor-pointer transition-transform" onclick="selectColor('white')"></div>


### PR DESCRIPTION
## Summary
- move card customization controls under the preview so they're displayed beneath the card on all screen sizes

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6875ca8fc4e08328ac6763904f8d9973