### PR TITLE
Add payment authorization step

### DIFF
--- a/assets/order.js
+++ b/assets/order.js
@@ -1,13 +1,17 @@
 const modal = document.getElementById('orderModal');
 const modalInfo = document.getElementById('modalInfo');
 const orderForm = document.getElementById('orderForm');
+const paymentInfo = document.getElementById('paymentInfo');
 const designCodeInput = document.getElementById('designCode');
+const authorizeBtn = document.getElementById('authorizeBtn');
+let orderBody = '';
 
 function openOrderModal(code) {
   designCodeInput.value = code || '';
   modal.classList.remove('hidden');
   modalInfo.classList.remove('hidden');
   orderForm.classList.add('hidden');
+  paymentInfo.classList.add('hidden');
 }
 
 document.querySelectorAll('.order-btn').forEach(btn => {
@@ -19,6 +23,7 @@ document.querySelectorAll('.order-btn').forEach(btn => {
 document.getElementById('acknowledgeBtn').addEventListener('click', () => {
   modalInfo.classList.add('hidden');
   orderForm.classList.remove('hidden');
+  paymentInfo.classList.add('hidden');
 });
 
 orderForm.addEventListener('submit', function(e) {
@@ -37,14 +42,26 @@ orderForm.addEventListener('submit', function(e) {
     address = addrParts.join(', ');
   }
 
-  const body =
+  orderBody =
     `Name: ${formData.get('name')}` + '\n' +
     `Email: ${formData.get('email')}` + '\n' +
     `Address: ${address}` + '\n' +
     `Design Code: ${formData.get('design')}` + '\n' +
     `Notes: ${formData.get('notes')}`;
+  orderForm.classList.add('hidden');
+  paymentInfo.classList.remove('hidden');
+});
 
-  window.location.href = `mailto:orders@schwarzusa.us?subject=Card%20Order&body=${encodeURIComponent(body)}`;
+authorizeBtn.addEventListener('click', () => {
+  const signature = document.getElementById('signature').value.trim();
+  if (!signature) {
+    alert('Please type your name to authorize.');
+    return;
+  }
+  const mailtoLink =
+    `mailto:orders@schwarzusa.us?subject=Card%20Order&body=${encodeURIComponent(orderBody + '\nSignature: ' + signature)}`;
+  window.open(mailtoLink);
+  window.location.href = 'https://square.link/u/uDJCvlMf';
   modal.classList.add('hidden');
 });
 

--- a/customize-card.html
+++ b/customize-card.html
@@ -220,6 +220,11 @@
         <textarea name="notes" placeholder="Additional notes" class="w-full border p-2"></textarea>
         <button type="submit" class="bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full">Submit</button>
       </form>
+      <div id="paymentInfo" class="hidden mt-4">
+        <p class="mb-4 text-sm font-semibold uppercase">BY COMPLETING ORDER, YOU AUTHORIZE SCHWARZ USA LLC CHARGE YOUR REPLACEMENT METAL CARD A MAXIMUM OF 5 TIMES ($0.20 EACH), NO MORE THAN $1.00 TOTAL, TO VERIFY ALL FEATURES ARE WORKING. THIS AMOUNT (≤$1.00) WILL BE REFUNDED WITHIN 7 BUSINESS DAYS FROM THE DATE OF TRANSACTION.</p>
+        <input type="text" id="signature" placeholder="Type your name to sign" class="w-full border p-2 mb-4" />
+        <button id="authorizeBtn" class="bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full">Authorize</button>
+      </div>
     </div>
   </div>
   <script src="assets/order.js"></script>

--- a/designs.html
+++ b/designs.html
@@ -110,6 +110,11 @@
         <textarea name="notes" placeholder="Additional notes" class="w-full border p-2"></textarea>
         <button type="submit" class="bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full">Submit</button>
       </form>
+      <div id="paymentInfo" class="hidden mt-4">
+        <p class="mb-4 text-sm font-semibold uppercase">BY COMPLETING ORDER, YOU AUTHORIZE SCHWARZ USA LLC CHARGE YOUR REPLACEMENT METAL CARD A MAXIMUM OF 5 TIMES ($0.20 EACH), NO MORE THAN $1.00 TOTAL, TO VERIFY ALL FEATURES ARE WORKING. THIS AMOUNT (≤$1.00) WILL BE REFUNDED WITHIN 7 BUSINESS DAYS FROM THE DATE OF TRANSACTION.</p>
+        <input type="text" id="signature" placeholder="Type your name to sign" class="w-full border p-2 mb-4" />
+        <button id="authorizeBtn" class="bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full">Authorize</button>
+      </div>
     </div>
   </div>
   <script src="assets/order.js"></script>

--- a/products.html
+++ b/products.html
@@ -110,6 +110,11 @@
         <textarea name="notes" placeholder="Additional notes" class="w-full border p-2"></textarea>
         <button type="submit" class="bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full">Submit</button>
       </form>
+      <div id="paymentInfo" class="hidden mt-4">
+        <p class="mb-4 text-sm font-semibold uppercase">BY COMPLETING ORDER, YOU AUTHORIZE SCHWARZ USA LLC CHARGE YOUR REPLACEMENT METAL CARD A MAXIMUM OF 5 TIMES ($0.20 EACH), NO MORE THAN $1.00 TOTAL, TO VERIFY ALL FEATURES ARE WORKING. THIS AMOUNT (≤$1.00) WILL BE REFUNDED WITHIN 7 BUSINESS DAYS FROM THE DATE OF TRANSACTION.</p>
+        <input type="text" id="signature" placeholder="Type your name to sign" class="w-full border p-2 mb-4" />
+        <button id="authorizeBtn" class="bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full">Authorize</button>
+      </div>
     </div>
   </div>
   <script src="assets/order.js"></script>


### PR DESCRIPTION
## Summary
- add a second acknowledgement step for orders
- implement signature authorization and redirect to Square payment link

## Testing
- `tidy -q -e designs.html`
- `tidy -q -e products.html`
- `tidy -q -e customize-card.html`


------
https://chatgpt.com/codex/tasks/task_e_68793b123648832896d38af27e7f1a9e