### PR TITLE
Fix order flow without customer form

### DIFF
--- a/assets/order.js
+++ b/assets/order.js
@@ -1,66 +1,28 @@
 const modal = document.getElementById('orderModal');
 const modalInfo = document.getElementById('modalInfo');
-const orderForm = document.getElementById('orderForm');
 const paymentInfo = document.getElementById('paymentInfo');
-const designCodeInput = document.getElementById('designCode');
 const authorizeBtn = document.getElementById('authorizeBtn');
-let orderBody = '';
 
-function openOrderModal(code) {
-  designCodeInput.value = code || '';
+function openOrderModal() {
   modal.classList.remove('hidden');
   modalInfo.classList.remove('hidden');
-  orderForm.classList.add('hidden');
   paymentInfo.classList.add('hidden');
 }
 
 document.querySelectorAll('.order-btn').forEach(btn => {
-  btn.addEventListener('click', () => {
-    openOrderModal(btn.dataset.code);
-  });
+  btn.addEventListener('click', openOrderModal);
 });
 
 document.getElementById('acknowledgeBtn').addEventListener('click', () => {
   modalInfo.classList.add('hidden');
-  orderForm.classList.remove('hidden');
-  paymentInfo.classList.add('hidden');
-});
-
-orderForm.addEventListener('submit', function(e) {
-  e.preventDefault();
-  const formData = new FormData(orderForm);
-
-  let address = formData.get('address');
-  if (!address) {
-    const addrParts = [
-      formData.get('Street Address'),
-      formData.get('Line 2'),
-      formData.get('City'),
-      formData.get('State'),
-      formData.get('Zip Code')
-    ].filter(Boolean);
-    address = addrParts.join(', ');
-  }
-
-  orderBody =
-    `Name: ${formData.get('name')}` + '\n' +
-    `Email: ${formData.get('email')}` + '\n' +
-    `Address: ${address}` + '\n' +
-    `Design Code: ${formData.get('design')}` + '\n' +
-    `Notes: ${formData.get('notes')}`;
-  orderForm.classList.add('hidden');
   paymentInfo.classList.remove('hidden');
 });
-
 authorizeBtn.addEventListener('click', () => {
   const signature = document.getElementById('signature').value.trim();
   if (!signature) {
     alert('Please type your name to authorize.');
     return;
   }
-  const mailtoLink =
-    `mailto:orders@schwarzusa.us?subject=Card%20Order&body=${encodeURIComponent(orderBody + '\nSignature: ' + signature)}`;
-  window.open(mailtoLink);
   window.location.href = 'https://square.link/u/uDJCvlMf';
   modal.classList.add('hidden');
 });

--- a/customize-card.html
+++ b/customize-card.html
@@ -208,7 +208,6 @@
         <p class="mb-4">Here’s how it works:<br>1. You submit your order to orders@schwarzusa.us in the order form.<br>2. We send you a box to send us your old card.<br>3. We create and send your new card along with what is left of the old card (if requested).<br><strong>NOTE:</strong> To transfer the chip to the new card, we partially submerge your old card in acetone to dissolve the plastic around the chip. Your old card will be unusable after this.</p>
         <button id="acknowledgeBtn" class="bg-gray-800 text-white px-4 py-2 rounded w-full">Acknowledge</button>
       </div>
-      </form>
       <div id="paymentInfo" class="hidden mt-4">
         <p class="mb-4 text-sm font-semibold uppercase">BY COMPLETING ORDER, YOU AUTHORIZE SCHWARZ USA LLC CHARGE YOUR REPLACEMENT METAL CARD A MAXIMUM OF 5 TIMES ($0.20 EACH), NO MORE THAN $1.00 TOTAL, TO VERIFY ALL FEATURES ARE WORKING. THIS AMOUNT (≤$1.00) WILL BE REFUNDED WITHIN 7 BUSINESS DAYS FROM THE DATE OF TRANSACTION.</p>
         <input type="text" id="signature" placeholder="Type your name to sign" class="w-full border p-2 mb-4" />

--- a/designs.html
+++ b/designs.html
@@ -102,14 +102,6 @@
         <p class="mb-4">Here’s how it works:<br>1. You submit your shipping address.<br>2. We send you a return box for your old card.<br>3. We create and send your new card along with your old card.<br><strong>NOTE:</strong> To transfer the chip to the new card, we partially submerge your old card in acetone to dissolve the plastic around the chip. Your old card will be unusable after this.</p>
         <button id="acknowledgeBtn" class="bg-[#e5e4e2] text-black px-4 py-2 rounded w-full">Acknowledge</button>
       </div>
-      <form id="orderForm" class="hidden mt-4 space-y-4">
-        <input type="text" name="name" placeholder="Name" required class="w-full border p-2" />
-        <input type="email" name="email" placeholder="Email" required class="w-full border p-2" />
-        <input type="text" name="address" placeholder="Address" required class="w-full border p-2" />
-        <input type="text" name="design" id="designCode" readonly class="w-full border p-2" />
-        <textarea name="notes" placeholder="Additional notes" class="w-full border p-2"></textarea>
-        <button type="submit" class="bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full">Submit</button>
-      </form>
       <div id="paymentInfo" class="hidden mt-4">
         <p class="mb-4 text-sm font-semibold uppercase">BY COMPLETING ORDER, YOU AUTHORIZE SCHWARZ USA LLC CHARGE YOUR REPLACEMENT METAL CARD A MAXIMUM OF 5 TIMES ($0.20 EACH), NO MORE THAN $1.00 TOTAL, TO VERIFY ALL FEATURES ARE WORKING. THIS AMOUNT (≤$1.00) WILL BE REFUNDED WITHIN 7 BUSINESS DAYS FROM THE DATE OF TRANSACTION.</p>
         <input type="text" id="signature" placeholder="Type your name to sign" class="w-full border p-2 mb-4" />

--- a/products.html
+++ b/products.html
@@ -102,14 +102,6 @@
         <p class="mb-4">Here’s how it works:<br>1. You submit your shipping address.<br>2. We send you a return box for your old card.<br>3. We create and send your new card along with your old card.<br><strong>NOTE:</strong> To transfer the chip to the new card, we partially submerge your old card in acetone to dissolve the plastic around the chip. Your old card will be unusable after this.</p>
         <button id="acknowledgeBtn" class="bg-[#e5e4e2] text-black px-4 py-2 rounded w-full">Acknowledge</button>
       </div>
-      <form id="orderForm" class="hidden mt-4 space-y-4">
-        <input type="text" name="name" placeholder="Name" required class="w-full border p-2" />
-        <input type="email" name="email" placeholder="Email" required class="w-full border p-2" />
-        <input type="text" name="address" placeholder="Address" required class="w-full border p-2" />
-        <input type="text" name="design" id="designCode" readonly class="w-full border p-2" />
-        <textarea name="notes" placeholder="Additional notes" class="w-full border p-2"></textarea>
-        <button type="submit" class="bg-[#d4af37] hover:bg-[#e0c94a] text-black px-4 py-2 rounded w-full">Submit</button>
-      </form>
       <div id="paymentInfo" class="hidden mt-4">
         <p class="mb-4 text-sm font-semibold uppercase">BY COMPLETING ORDER, YOU AUTHORIZE SCHWARZ USA LLC CHARGE YOUR REPLACEMENT METAL CARD A MAXIMUM OF 5 TIMES ($0.20 EACH), NO MORE THAN $1.00 TOTAL, TO VERIFY ALL FEATURES ARE WORKING. THIS AMOUNT (≤$1.00) WILL BE REFUNDED WITHIN 7 BUSINESS DAYS FROM THE DATE OF TRANSACTION.</p>
         <input type="text" id="signature" placeholder="Type your name to sign" class="w-full border p-2 mb-4" />


### PR DESCRIPTION
## Summary
- remove customer information form from order modal
- simplify `order.js` to skip form step
- keep two-step acknowledgement then payment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879405c7104832884d632ab47b2830e